### PR TITLE
Add local dev session support for testing against live captions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ You can run this front end locally and connect it to **any broadcaster currently
 captioning** on the live site, to confirm that extension changes didn't break
 caption rendering against real data. This is gated to the site owner: the channel
 list and connection token come from an admin-only page on the backend (restricted
-to the owner account), and the whole feature is stripped from production builds.
+to the owner account), and the whole feature is dev-mode-gated so it stays inert
+in production builds.
 
 ### One-time backend setup
 
@@ -111,6 +112,6 @@ Leave it unset everywhere else — without it, local origins are rejected.
   socket. The fragment is cleared from the address bar after it's read.
 - `useTwitchAuth` synthesizes a Twitch-style auth object from that session when
   there's no Twitch host, so the normal caption subscription flow runs unchanged.
-- Everything is gated on `import.meta.env.MODE === 'development'`, so none of it
-  ships in the production extension bundle.
+- Everything is gated on `import.meta.env.MODE === 'development'`, so it stays
+  inert in production builds — the same approach as the existing mock harness.
 

--- a/README.md
+++ b/README.md
@@ -99,19 +99,32 @@ Leave it unset everywhere else — without it, local origins are rejected.
 2. While logged in as the owner, open **Admin → Local Extension Testing** on the
    site. It lists every channel currently publishing captions.
 3. Click **Overlay →** (or **Mobile →**) next to a channel. This opens your local
-   build with a short-lived socket token and the channel id in the URL fragment;
-   the page connects straight to that broadcaster's live captions.
+   build with a short-lived socket token **minted for that channel**, the channel
+   id, and the backend's origin in the URL fragment; the page connects straight
+   to that broadcaster's live captions on whichever deploy minted the link.
 4. To switch channels without revisiting the admin page, open **Mock Controls
    (Dev)** → **Live Channel (Dev)**, paste a channel id, and click *Connect*.
-   *Disconnect live session* returns you to the mock harness.
+   *Disconnect live session* returns you to the mock harness. (Note: switching
+   this way reuses the stored token, so channel-scoped queries like translation
+   status still reflect the token's original channel — captions follow the new
+   channel.)
+
+Tokens expire after ~2 hours; an expired session is discarded automatically on
+the next load (the build falls back to the mock harness), so just open a fresh
+link from the admin page.
 
 ### How it works
 
-- `src/utils/localDevSession.js` reads the token + channel id from the URL
-  fragment, persists them, switches Apollo to the real server, and opens the
-  socket. The fragment is cleared from the address bar after it's read.
-- `useTwitchAuth` synthesizes a Twitch-style auth object from that session when
-  there's no Twitch host, so the normal caption subscription flow runs unchanged.
+- `src/utils/localDevSession.js` reads the token, channel id, and backend origin
+  from the URL fragment, persists them under dedicated `scc_dev_*` localStorage
+  keys (never the primary `token` key the Twitch host uses), switches Apollo to
+  the real server, and opens the socket against the seeded backend. The fragment
+  is cleared from the address bar after it's read.
+- `useTwitchAuth` synthesizes a Twitch-style auth object from that session
+  *before* deferring to the Twitch host — the CDN helper script defines
+  `window.Twitch.ext` even outside a Twitch iframe, so the dev session must take
+  precedence. `useTwitchContext` seeds a matching player context
+  (controls visible, zero HLS latency) since `onContext` never fires locally.
 - Everything is gated on `import.meta.env.MODE === 'development'`, so it stays
   inert in production builds — the same approach as the existing mock harness.
 

--- a/README.md
+++ b/README.md
@@ -72,3 +72,45 @@ The following GraphQL operations have mock implementations:
 
 Mock functionality is **completely disabled** in production builds. The production bundle uses the real GraphQL endpoints configured in `src/utils/apollo.js`.
 
+## Local Testing Against Live Captions (maintainer only)
+
+You can run this front end locally and connect it to **any broadcaster currently
+captioning** on the live site, to confirm that extension changes didn't break
+caption rendering against real data. This is gated to the site owner: the channel
+list and connection token come from an admin-only page on the backend (restricted
+to the owner account), and the whole feature is stripped from production builds.
+
+### One-time backend setup
+
+On the deployment you want to test against, set the env var
+`LOCAL_EXT_TESTING_ORIGINS` to your local origin so the websocket accepts the
+connection (comma-separated for multiple), e.g.:
+
+```
+LOCAL_EXT_TESTING_ORIGINS=http://localhost:8080
+```
+
+Leave it unset everywhere else — without it, local origins are rejected.
+
+### Connecting
+
+1. Start the dev server: `yarn start` (serves on `http://localhost:8080`).
+2. While logged in as the owner, open **Admin → Local Extension Testing** on the
+   site. It lists every channel currently publishing captions.
+3. Click **Overlay →** (or **Mobile →**) next to a channel. This opens your local
+   build with a short-lived socket token and the channel id in the URL fragment;
+   the page connects straight to that broadcaster's live captions.
+4. To switch channels without revisiting the admin page, open **Mock Controls
+   (Dev)** → **Live Channel (Dev)**, paste a channel id, and click *Connect*.
+   *Disconnect live session* returns you to the mock harness.
+
+### How it works
+
+- `src/utils/localDevSession.js` reads the token + channel id from the URL
+  fragment, persists them, switches Apollo to the real server, and opens the
+  socket. The fragment is cleared from the address bar after it's read.
+- `useTwitchAuth` synthesizes a Twitch-style auth object from that session when
+  there's no Twitch host, so the normal caption subscription flow runs unchanged.
+- Everything is gated on `import.meta.env.MODE === 'development'`, so none of it
+  ships in the production extension bundle.
+

--- a/src/components/DevMockControlsDialog/DevMockControlsDialog.jsx
+++ b/src/components/DevMockControlsDialog/DevMockControlsDialog.jsx
@@ -18,6 +18,7 @@ import {
   getLocalDevSession,
   setLocalDevChannel,
   clearLocalDevSession,
+  hasLocalDevToken,
 } from '@/utils/localDevSession'
 
 /**
@@ -33,11 +34,13 @@ function DevMockControlsDialog({ isOpen, onClose }) {
   const [finalText, setFinalText] = useState('')
   const [liveChannelInput, setLiveChannelInput] = useState('')
   const [connectedChannel, setConnectedChannel] = useState('')
+  const [hasDevToken, setHasDevToken] = useState(false)
 
   // Sync config state when dialog opens
   const handleOpening = useCallback(() => {
     setConfig(getMockConfig())
     setConnectedChannel(getLocalDevSession()?.channelId || '')
+    setHasDevToken(hasLocalDevToken())
   }, [])
 
   // Update mock configuration
@@ -101,7 +104,8 @@ function DevMockControlsDialog({ isOpen, onClose }) {
   const handleConnectLiveChannel = useCallback(() => {
     const channelId = liveChannelInput.trim()
 
-    if (!channelId) {
+    // Without a seeded token, reloading can't connect — so don't bother.
+    if (!channelId || !hasLocalDevToken()) {
       return
     }
 
@@ -231,7 +235,14 @@ function DevMockControlsDialog({ isOpen, onClose }) {
               ? `Connected to channel ${connectedChannel}`
               : 'No live session active'}
           </p>
+          {!hasDevToken && (
+            <p className="bp5-text-muted bp5-text-small">
+              No socket token loaded — open a link from the admin &quot;Local
+              Extension Testing&quot; page first to seed one.
+            </p>
+          )}
           <InputGroup
+            disabled={!hasDevToken}
             fill
             id="live-channel-input"
             onChange={handleLiveChannelChange}
@@ -240,7 +251,7 @@ function DevMockControlsDialog({ isOpen, onClose }) {
             value={liveChannelInput}
           />
           <Button
-            disabled={!liveChannelInput.trim()}
+            disabled={!hasDevToken || !liveChannelInput.trim()}
             fill
             intent="primary"
             onClick={handleConnectLiveChannel}

--- a/src/components/DevMockControlsDialog/DevMockControlsDialog.jsx
+++ b/src/components/DevMockControlsDialog/DevMockControlsDialog.jsx
@@ -96,13 +96,16 @@ function DevMockControlsDialog({ isOpen, onClose }) {
 
   // Switch the local build to a different live channel (reuses the stored
   // token) and reload so the websocket reconnects with the new subscription.
+  // The real-server flag is re-applied by loadLocalDevSession() after reload,
+  // so there's no need to set it here (it would be discarded by the reload).
   const handleConnectLiveChannel = useCallback(() => {
-    if (!liveChannelInput) {
+    const channelId = liveChannelInput.trim()
+
+    if (!channelId) {
       return
     }
 
-    setLocalDevChannel(liveChannelInput.trim())
-    updateMockConfig({ useRealServer: true })
+    setLocalDevChannel(channelId)
     window.location.reload()
   }, [liveChannelInput])
 
@@ -221,6 +224,7 @@ function DevMockControlsDialog({ isOpen, onClose }) {
         <FormGroup
           helperText="Connect to a real, currently-live broadcaster's captions. Open a link from the admin 'Local Extension Testing' page, or paste a channel id below to switch (reuses the stored token)."
           label="Live Channel (Dev)"
+          labelFor="live-channel-input"
         >
           <p className="bp5-text-muted bp5-text-small">
             {connectedChannel
@@ -229,13 +233,14 @@ function DevMockControlsDialog({ isOpen, onClose }) {
           </p>
           <InputGroup
             fill
+            id="live-channel-input"
             onChange={handleLiveChannelChange}
             placeholder="Twitch channel/user id"
             style={{ marginTop: '8px' }}
             value={liveChannelInput}
           />
           <Button
-            disabled={!liveChannelInput}
+            disabled={!liveChannelInput.trim()}
             fill
             intent="primary"
             onClick={handleConnectLiveChannel}

--- a/src/components/DevMockControlsDialog/DevMockControlsDialog.jsx
+++ b/src/components/DevMockControlsDialog/DevMockControlsDialog.jsx
@@ -14,6 +14,11 @@ import {
   updateMockConfig,
   triggerSubscriptionEvent,
 } from '@/utils/graphql-mocks'
+import {
+  getLocalDevSession,
+  setLocalDevChannel,
+  clearLocalDevSession,
+} from '@/utils/localDevSession'
 
 /**
  * Dev-only dialog for controlling GraphQL mock behavior
@@ -26,10 +31,13 @@ function DevMockControlsDialog({ isOpen, onClose }) {
   const [config, setConfig] = useState(getMockConfig())
   const [interimText, setInterimText] = useState('')
   const [finalText, setFinalText] = useState('')
+  const [liveChannelInput, setLiveChannelInput] = useState('')
+  const [connectedChannel, setConnectedChannel] = useState('')
 
   // Sync config state when dialog opens
   const handleOpening = useCallback(() => {
     setConfig(getMockConfig())
+    setConnectedChannel(getLocalDevSession()?.channelId || '')
   }, [])
 
   // Update mock configuration
@@ -80,6 +88,27 @@ function DevMockControlsDialog({ isOpen, onClose }) {
 
   const handleFinalChange = useCallback((e) => {
     setFinalText(e.target.value)
+  }, [])
+
+  const handleLiveChannelChange = useCallback((e) => {
+    setLiveChannelInput(e.target.value)
+  }, [])
+
+  // Switch the local build to a different live channel (reuses the stored
+  // token) and reload so the websocket reconnects with the new subscription.
+  const handleConnectLiveChannel = useCallback(() => {
+    if (!liveChannelInput) {
+      return
+    }
+
+    setLocalDevChannel(liveChannelInput.trim())
+    updateMockConfig({ useRealServer: true })
+    window.location.reload()
+  }, [liveChannelInput])
+
+  const handleClearLiveSession = useCallback(() => {
+    clearLocalDevSession()
+    window.location.reload()
   }, [])
 
   return (
@@ -186,6 +215,42 @@ function DevMockControlsDialog({ isOpen, onClose }) {
             >
               Manual triggers are disabled when using the real server
             </p>
+          )}
+        </FormGroup>
+
+        <FormGroup
+          helperText="Connect to a real, currently-live broadcaster's captions. Open a link from the admin 'Local Extension Testing' page, or paste a channel id below to switch (reuses the stored token)."
+          label="Live Channel (Dev)"
+        >
+          <p className="bp5-text-muted bp5-text-small">
+            {connectedChannel
+              ? `Connected to channel ${connectedChannel}`
+              : 'No live session active'}
+          </p>
+          <InputGroup
+            fill
+            onChange={handleLiveChannelChange}
+            placeholder="Twitch channel/user id"
+            style={{ marginTop: '8px' }}
+            value={liveChannelInput}
+          />
+          <Button
+            disabled={!liveChannelInput}
+            fill
+            intent="primary"
+            onClick={handleConnectLiveChannel}
+            style={{ marginTop: '8px' }}
+            text="Connect to live channel"
+          />
+          {connectedChannel && (
+            <Button
+              fill
+              intent="danger"
+              minimal
+              onClick={handleClearLiveSession}
+              style={{ marginTop: '8px' }}
+              text="Disconnect live session"
+            />
           )}
         </FormGroup>
       </div>

--- a/src/components/display-settings-menu/__tests__/DisplaySettings.test.jsx
+++ b/src/components/display-settings-menu/__tests__/DisplaySettings.test.jsx
@@ -56,6 +56,37 @@ describe('displaySettings', () => {
       })
     })
 
+    describe('settings position is default', () => {
+      test('positions the controls on the right', () => {
+        const { queryByTestId } = renderWithRedux(<DisplaySettingsMenu />, {
+          initialState: {
+            videoPlayerContext: { arePlayerControlsVisible: true },
+          },
+        })
+
+        expect(queryByTestId('display-settings')).toHaveClass('position-right')
+        expect(queryByTestId('display-settings')).not.toHaveClass(
+          'position-left',
+        )
+      })
+    })
+
+    describe('settings position is switched', () => {
+      test('positions the controls on the left', () => {
+        const { queryByTestId } = renderWithRedux(<DisplaySettingsMenu />, {
+          initialState: {
+            configSettings: { switchSettingsPosition: true },
+            videoPlayerContext: { arePlayerControlsVisible: true },
+          },
+        })
+
+        expect(queryByTestId('display-settings')).toHaveClass('position-left')
+        expect(queryByTestId('display-settings')).not.toHaveClass(
+          'position-right',
+        )
+      })
+    })
+
     describe('arePlayerControlsVisible is false', () => {
       test('renders enable horizontal text', () => {
         const { queryByTestId } = renderWithRedux(<DisplaySettingsMenu />, {

--- a/src/components/display-settings-menu/settings-menu.css
+++ b/src/components/display-settings-menu/settings-menu.css
@@ -7,7 +7,8 @@
 .settings-menu-container {
   position: absolute;
   top: 100%;
-  left: 0;
+  right: 0;
+  left: auto;
   background-color: #30404d;
   border: 1px solid #10161a;
   border-radius: 3px;
@@ -19,6 +20,16 @@
   display: block !important;
   visibility: visible !important;
   opacity: 1 !important;
+}
+
+.position-left .settings-menu-container {
+  left: 0;
+  right: auto;
+}
+
+.position-right .settings-menu-container {
+  right: 0;
+  left: auto;
 }
 
 /* Blueprint Menu styling */
@@ -61,5 +72,3 @@
 .settings-menu-container .bp5-submenu-icon {
   margin-left: auto;
 }
-
-

--- a/src/hooks/__tests__/useTwitchAuth.test.jsx
+++ b/src/hooks/__tests__/useTwitchAuth.test.jsx
@@ -138,4 +138,30 @@ describe('useTwitchAuth', () => {
 
     expect(result.current.authorized).toBe(false)
   })
+
+  test('prefers a local dev session even when the Twitch helper script is present', async () => {
+    // The CDN helper defines window.Twitch.ext even outside a Twitch iframe,
+    // where onAuthorized never fires — the dev session must win there.
+    const mockOnAuthorized = vi.fn()
+    window.Twitch = {
+      ext: {
+        onAuthorized: mockOnAuthorized,
+      },
+    }
+    vi.mocked(isLocalDevEnabled).mockReturnValue(true)
+    vi.mocked(loadLocalDevSession).mockReturnValue({
+      token: 'dev.jwt.token',
+      channelId: '999',
+      backend: null,
+    })
+
+    const { result } = renderHook(() => useTwitchAuth())
+
+    await waitFor(() => {
+      expect(result.current.authorized).toBe(true)
+      expect(result.current.channelId).toBe('999')
+    })
+
+    expect(mockOnAuthorized).not.toHaveBeenCalled()
+  })
 })

--- a/src/hooks/__tests__/useTwitchAuth.test.jsx
+++ b/src/hooks/__tests__/useTwitchAuth.test.jsx
@@ -1,11 +1,23 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useTwitchAuth } from '../useTwitchAuth'
+import {
+  isLocalDevEnabled,
+  loadLocalDevSession,
+} from '../../utils/localDevSession'
+
+vi.mock('../../utils/localDevSession', () => ({
+  isLocalDevEnabled: vi.fn(() => false),
+  loadLocalDevSession: vi.fn(() => null),
+}))
 
 describe('useTwitchAuth', () => {
   beforeEach(() => {
     // Reset Twitch mock before each test
     delete window.Twitch
+    // Local dev seam defaults to off so the Twitch-host tests are unaffected.
+    vi.mocked(isLocalDevEnabled).mockReturnValue(false)
+    vi.mocked(loadLocalDevSession).mockReturnValue(null)
   })
 
   afterEach(() => {
@@ -96,6 +108,34 @@ describe('useTwitchAuth', () => {
     }).not.toThrow()
 
     const { result } = renderHook(() => useTwitchAuth())
+    expect(result.current.authorized).toBe(false)
+  })
+
+  test('synthesizes auth from a local dev session when Twitch is absent', async () => {
+    delete window.Twitch
+    vi.mocked(isLocalDevEnabled).mockReturnValue(true)
+    vi.mocked(loadLocalDevSession).mockReturnValue({
+      token: 'dev.jwt.token',
+      channelId: '12345',
+    })
+
+    const { result } = renderHook(() => useTwitchAuth())
+
+    await waitFor(() => {
+      expect(result.current.authorized).toBe(true)
+      expect(result.current.channelId).toBe('12345')
+      expect(result.current.token).toBe('dev.jwt.token')
+      expect(result.current.userId).toBe('120750024')
+    })
+  })
+
+  test('does not synthesize auth when no dev session exists', () => {
+    delete window.Twitch
+    vi.mocked(isLocalDevEnabled).mockReturnValue(true)
+    vi.mocked(loadLocalDevSession).mockReturnValue(null)
+
+    const { result } = renderHook(() => useTwitchAuth())
+
     expect(result.current.authorized).toBe(false)
   })
 })

--- a/src/hooks/__tests__/useTwitchContext.test.jsx
+++ b/src/hooks/__tests__/useTwitchContext.test.jsx
@@ -1,10 +1,22 @@
 import { renderHook } from '@testing-library/react'
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useTwitchContext } from '../useTwitchContext'
+import {
+  isLocalDevEnabled,
+  getLocalDevSession,
+} from '../../utils/localDevSession'
+
+vi.mock('../../utils/localDevSession', () => ({
+  isLocalDevEnabled: vi.fn(() => false),
+  getLocalDevSession: vi.fn(() => null),
+}))
 
 describe('useTwitchContext', () => {
   beforeEach(() => {
     delete window.Twitch
+    // Local dev seam defaults to off so the Twitch-host tests are unaffected.
+    vi.mocked(isLocalDevEnabled).mockReturnValue(false)
+    vi.mocked(getLocalDevSession).mockReturnValue(null)
   })
 
   afterEach(() => {
@@ -112,5 +124,34 @@ describe('useTwitchContext', () => {
     const { result } = renderHook(() => useTwitchContext(mockCallback))
 
     expect(result.current).toBeUndefined()
+  })
+
+  test('synthesizes a player context for an active local dev session', () => {
+    // The Twitch player never emits onContext during local dev sessions, so
+    // sensible defaults keep the overlay controls reachable and the caption
+    // delay finite (instead of NaN from an undefined hlsLatencyBroadcaster).
+    vi.mocked(isLocalDevEnabled).mockReturnValue(true)
+    vi.mocked(getLocalDevSession).mockReturnValue({
+      token: 'dev.jwt.token',
+      channelId: '999',
+      backend: null,
+    })
+    const mockCallback = vi.fn()
+
+    renderHook(() => useTwitchContext(mockCallback))
+
+    expect(mockCallback).toHaveBeenCalledWith({
+      arePlayerControlsVisible: true,
+      hlsLatencyBroadcaster: 0,
+    })
+  })
+
+  test('does not synthesize a context without a dev session', () => {
+    vi.mocked(isLocalDevEnabled).mockReturnValue(true)
+    const mockCallback = vi.fn()
+
+    renderHook(() => useTwitchContext(mockCallback))
+
+    expect(mockCallback).not.toHaveBeenCalled()
   })
 })

--- a/src/hooks/useTwitchAuth.js
+++ b/src/hooks/useTwitchAuth.js
@@ -1,5 +1,14 @@
 import { useState, useEffect } from 'react'
 
+import {
+  isLocalDevEnabled,
+  loadLocalDevSession,
+} from '../utils/localDevSession'
+
+// Owner account uid. Only used to populate a plausible userId for the
+// synthesized local-dev auth; the backend trusts the JWT, not this value.
+const LOCAL_DEV_USER_ID = '120750024'
+
 export const useTwitchAuth = () => {
   const [twitchAuth, setTwitchAuth] = useState({
     authorized: false,
@@ -16,6 +25,24 @@ export const useTwitchAuth = () => {
       twitchContext.onAuthorized((twitchResponse) => {
         setTwitchAuth({ authorized: true, ...twitchResponse })
       })
+      return
+    }
+
+    // Running locally, outside the Twitch host. If a dev session was seeded via
+    // the admin "Local Extension Testing" page, behave as if Twitch authorized
+    // us for that broadcaster so the normal caption flow runs unchanged.
+    if (isLocalDevEnabled()) {
+      const session = loadLocalDevSession()
+
+      if (session) {
+        setTwitchAuth({
+          authorized: true,
+          channelId: session.channelId,
+          clientId: 'local-dev',
+          token: session.token,
+          userId: LOCAL_DEV_USER_ID,
+        })
+      }
     }
   }, [twitchContext])
 

--- a/src/hooks/useTwitchAuth.js
+++ b/src/hooks/useTwitchAuth.js
@@ -21,16 +21,11 @@ export const useTwitchAuth = () => {
   const twitchContext = window.Twitch?.ext
 
   useEffect(() => {
-    if (twitchContext) {
-      twitchContext.onAuthorized((twitchResponse) => {
-        setTwitchAuth({ authorized: true, ...twitchResponse })
-      })
-      return
-    }
-
-    // Running locally, outside the Twitch host. If a dev session was seeded via
-    // the admin "Local Extension Testing" page, behave as if Twitch authorized
-    // us for that broadcaster so the normal caption flow runs unchanged.
+    // Check for an admin-seeded dev session BEFORE deferring to the Twitch
+    // host: the helper script (loaded from Twitch's CDN in every HTML entry
+    // point) defines window.Twitch.ext even outside a Twitch iframe, where
+    // onAuthorized would never fire — so a dev session must take precedence
+    // for the local testing flow to be reachable at all.
     if (isLocalDevEnabled()) {
       const session = loadLocalDevSession()
 
@@ -42,7 +37,15 @@ export const useTwitchAuth = () => {
           token: session.token,
           userId: LOCAL_DEV_USER_ID,
         })
+
+        return
       }
+    }
+
+    if (twitchContext) {
+      twitchContext.onAuthorized((twitchResponse) => {
+        setTwitchAuth({ authorized: true, ...twitchResponse })
+      })
     }
   }, [twitchContext])
 

--- a/src/hooks/useTwitchContext.js
+++ b/src/hooks/useTwitchContext.js
@@ -1,15 +1,32 @@
 import { pick, pipe } from 'ramda'
 import { useEffect } from 'react'
 
+import { isLocalDevEnabled, getLocalDevSession } from '../utils/localDevSession'
+
 const CONTEXT_EVENTS_WHITELIST = [
   'arePlayerControlsVisible',
   'hlsLatencyBroadcaster',
   'displayResolution',
 ]
 
+// Defaults for local dev sessions, where the Twitch player never emits
+// onContext: keep the overlay controls reachable and don't delay captions by
+// an unknown (NaN) HLS latency.
+const LOCAL_DEV_CONTEXT = {
+  arePlayerControlsVisible: true,
+  hlsLatencyBroadcaster: 0,
+}
+
 export const useTwitchContext = (callback) => {
   const itsTwitch = window.Twitch?.ext
   useEffect(() => {
+    // An admin-seeded dev session gets a synthesized context, since the real
+    // one only ever arrives inside the Twitch player.
+    if (isLocalDevEnabled() && getLocalDevSession()) {
+      callback(LOCAL_DEV_CONTEXT)
+      return
+    }
+
     if (itsTwitch) {
       itsTwitch.onContext((context, delta) => {
         pipe(pick(delta), pick(CONTEXT_EVENTS_WHITELIST), callback)(context)

--- a/src/utils/Authentication.js
+++ b/src/utils/Authentication.js
@@ -2,7 +2,7 @@
  * Decodes a JWT payload without verifying the signature.
  * Verification happens server-side; this only reads the claims.
  */
-function decodeJwtPayload(token) {
+export function decodeJwtPayload(token) {
   const base64Url = token.split('.')[1]
   let base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
   // Normalize base64url payloads that omit trailing = padding

--- a/src/utils/__tests__/localDevSession.test.js
+++ b/src/utils/__tests__/localDevSession.test.js
@@ -88,6 +88,16 @@ describe('localDevSession', () => {
       expect(localStorage.getItem('token')).toBeNull()
       expect(updateMockConfig).not.toHaveBeenCalled()
     })
+
+    test('trims fragment values and ignores whitespace-only ones', () => {
+      window.location.hash = '#scc_dev_token=%20%20&scc_dev_channel=%20%20'
+
+      const session = loadLocalDevSession()
+
+      expect(session).toBeNull()
+      expect(localStorage.getItem('token')).toBeNull()
+      expect(localStorage.getItem('scc_dev_channel')).toBeNull()
+    })
   })
 
   describe('getLocalDevSession', () => {
@@ -98,9 +108,20 @@ describe('localDevSession', () => {
   })
 
   describe('setLocalDevChannel', () => {
-    test('updates the stored channel id', () => {
-      setLocalDevChannel('555')
+    test('updates the stored channel id, trimming whitespace', () => {
+      setLocalDevChannel('  555  ')
       expect(localStorage.getItem('scc_dev_channel')).toBe('555')
+    })
+
+    test('ignores empty/whitespace input', () => {
+      setLocalDevChannel('   ')
+      expect(localStorage.getItem('scc_dev_channel')).toBeNull()
+    })
+
+    test('is a no-op outside development mode', () => {
+      vi.stubEnv('MODE', 'production')
+      setLocalDevChannel('555')
+      expect(localStorage.getItem('scc_dev_channel')).toBeNull()
     })
   })
 
@@ -114,6 +135,16 @@ describe('localDevSession', () => {
       expect(localStorage.getItem('token')).toBeNull()
       expect(localStorage.getItem('scc_dev_channel')).toBeNull()
       expect(updateMockConfig).toHaveBeenCalledWith({ useRealServer: false })
+    })
+
+    test('is a no-op outside development mode (leaves the auth token intact)', () => {
+      vi.stubEnv('MODE', 'production')
+      localStorage.setItem('token', 'real-auth-token')
+
+      clearLocalDevSession()
+
+      expect(localStorage.getItem('token')).toBe('real-auth-token')
+      expect(updateMockConfig).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/utils/__tests__/localDevSession.test.js
+++ b/src/utils/__tests__/localDevSession.test.js
@@ -1,0 +1,119 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('../graphql-mocks', () => ({
+  updateMockConfig: vi.fn(),
+}))
+
+vi.mock('../apollo', () => ({
+  initializePhoenixSocket: vi.fn(),
+  connectPhoenixSocket: vi.fn(),
+}))
+
+import { updateMockConfig } from '../graphql-mocks'
+import { initializePhoenixSocket, connectPhoenixSocket } from '../apollo'
+import {
+  isLocalDevEnabled,
+  getLocalDevSession,
+  loadLocalDevSession,
+  setLocalDevChannel,
+  clearLocalDevSession,
+} from '../localDevSession'
+
+describe('localDevSession', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    vi.stubEnv('MODE', 'development')
+    window.location.hash = ''
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    window.location.hash = ''
+  })
+
+  describe('isLocalDevEnabled', () => {
+    test('is true in development mode', () => {
+      expect(isLocalDevEnabled()).toBe(true)
+    })
+
+    test('is false outside development mode', () => {
+      vi.stubEnv('MODE', 'production')
+      expect(isLocalDevEnabled()).toBe(false)
+    })
+  })
+
+  describe('loadLocalDevSession', () => {
+    test('seeds a session from the URL fragment and enables the real server', () => {
+      window.location.hash = '#scc_dev_token=jwt.abc.def&scc_dev_channel=12345'
+
+      const session = loadLocalDevSession()
+
+      expect(session).toEqual({ token: 'jwt.abc.def', channelId: '12345' })
+      expect(localStorage.getItem('token')).toBe('jwt.abc.def')
+      expect(localStorage.getItem('scc_dev_channel')).toBe('12345')
+      expect(updateMockConfig).toHaveBeenCalledWith({ useRealServer: true })
+      expect(initializePhoenixSocket).toHaveBeenCalled()
+      expect(connectPhoenixSocket).toHaveBeenCalled()
+      // Fragment is stripped so the token doesn't linger in the address bar.
+      expect(window.location.hash).toBe('')
+    })
+
+    test('returns a previously persisted session when no fragment is present', () => {
+      localStorage.setItem('token', 'stored.jwt')
+      localStorage.setItem('scc_dev_channel', '999')
+
+      const session = loadLocalDevSession()
+
+      expect(session).toEqual({ token: 'stored.jwt', channelId: '999' })
+      expect(updateMockConfig).toHaveBeenCalledWith({ useRealServer: true })
+      expect(connectPhoenixSocket).toHaveBeenCalled()
+    })
+
+    test('does nothing without a session', () => {
+      const session = loadLocalDevSession()
+
+      expect(session).toBeNull()
+      expect(updateMockConfig).not.toHaveBeenCalled()
+      expect(connectPhoenixSocket).not.toHaveBeenCalled()
+    })
+
+    test('is inert outside development mode', () => {
+      vi.stubEnv('MODE', 'production')
+      window.location.hash = '#scc_dev_token=jwt.abc.def&scc_dev_channel=12345'
+
+      const session = loadLocalDevSession()
+
+      expect(session).toBeNull()
+      expect(localStorage.getItem('token')).toBeNull()
+      expect(updateMockConfig).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getLocalDevSession', () => {
+    test('returns null when token or channel is missing', () => {
+      localStorage.setItem('token', 'only-token')
+      expect(getLocalDevSession()).toBeNull()
+    })
+  })
+
+  describe('setLocalDevChannel', () => {
+    test('updates the stored channel id', () => {
+      setLocalDevChannel('555')
+      expect(localStorage.getItem('scc_dev_channel')).toBe('555')
+    })
+  })
+
+  describe('clearLocalDevSession', () => {
+    test('removes the session and returns to mocks', () => {
+      localStorage.setItem('token', 'stored.jwt')
+      localStorage.setItem('scc_dev_channel', '999')
+
+      clearLocalDevSession()
+
+      expect(localStorage.getItem('token')).toBeNull()
+      expect(localStorage.getItem('scc_dev_channel')).toBeNull()
+      expect(updateMockConfig).toHaveBeenCalledWith({ useRealServer: false })
+    })
+  })
+})

--- a/src/utils/__tests__/localDevSession.test.js
+++ b/src/utils/__tests__/localDevSession.test.js
@@ -7,10 +7,15 @@ vi.mock('../graphql-mocks', () => ({
 vi.mock('../apollo', () => ({
   initializePhoenixSocket: vi.fn(),
   connectPhoenixSocket: vi.fn(),
+  disconnectPhoenixSocket: vi.fn(),
 }))
 
 import { updateMockConfig } from '../graphql-mocks'
-import { initializePhoenixSocket, connectPhoenixSocket } from '../apollo'
+import {
+  initializePhoenixSocket,
+  connectPhoenixSocket,
+  disconnectPhoenixSocket,
+} from '../apollo'
 import {
   isLocalDevEnabled,
   getLocalDevSession,
@@ -135,6 +140,7 @@ describe('localDevSession', () => {
       expect(localStorage.getItem('token')).toBeNull()
       expect(localStorage.getItem('scc_dev_channel')).toBeNull()
       expect(updateMockConfig).toHaveBeenCalledWith({ useRealServer: false })
+      expect(disconnectPhoenixSocket).toHaveBeenCalled()
     })
 
     test('is a no-op outside development mode (leaves the auth token intact)', () => {

--- a/src/utils/__tests__/localDevSession.test.js
+++ b/src/utils/__tests__/localDevSession.test.js
@@ -24,6 +24,21 @@ import {
   clearLocalDevSession,
   hasLocalDevToken,
 } from '../localDevSession'
+import { getSocketUrl, getGraphqlUrl } from '../devSessionStorage'
+
+/**
+ * Builds a decodable (unsigned) JWT so the session helpers can read claims.
+ * No exp claim means the token never expires.
+ */
+function fakeJwt(payload = {}) {
+  const body = btoa(JSON.stringify(payload))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+  return `header.${body}.signature`
+}
+
+const expiredJwt = () => fakeJwt({ exp: Math.floor(Date.now() / 1000) - 60 })
 
 describe('localDevSession', () => {
   beforeEach(() => {
@@ -51,12 +66,13 @@ describe('localDevSession', () => {
 
   describe('loadLocalDevSession', () => {
     test('seeds a session from the URL fragment and enables the real server', () => {
-      window.location.hash = '#scc_dev_token=jwt.abc.def&scc_dev_channel=12345'
+      const token = fakeJwt()
+      window.location.hash = `#scc_dev_token=${token}&scc_dev_channel=12345`
 
       const session = loadLocalDevSession()
 
-      expect(session).toEqual({ token: 'jwt.abc.def', channelId: '12345' })
-      expect(localStorage.getItem('token')).toBe('jwt.abc.def')
+      expect(session).toEqual({ token, channelId: '12345', backend: null })
+      expect(localStorage.getItem('scc_dev_token')).toBe(token)
       expect(localStorage.getItem('scc_dev_channel')).toBe('12345')
       expect(updateMockConfig).toHaveBeenCalledWith({ useRealServer: true })
       expect(initializePhoenixSocket).toHaveBeenCalled()
@@ -65,15 +81,59 @@ describe('localDevSession', () => {
       expect(window.location.hash).toBe('')
     })
 
+    test('seeds the backend origin from the fragment when present', () => {
+      const token = fakeJwt()
+      const backend = encodeURIComponent('https://staging.example.com')
+      window.location.hash = `#scc_dev_token=${token}&scc_dev_channel=12345&scc_dev_backend=${backend}`
+
+      const session = loadLocalDevSession()
+
+      expect(session).toEqual({
+        token,
+        channelId: '12345',
+        backend: 'https://staging.example.com',
+      })
+      expect(localStorage.getItem('scc_dev_backend')).toBe(
+        'https://staging.example.com',
+      )
+    })
+
+    test('clears a stale backend when a new session omits it', () => {
+      localStorage.setItem('scc_dev_backend', 'https://old.example.com')
+      const token = fakeJwt()
+      window.location.hash = `#scc_dev_token=${token}&scc_dev_channel=12345`
+
+      const session = loadLocalDevSession()
+
+      expect(session.backend).toBeNull()
+      expect(localStorage.getItem('scc_dev_backend')).toBeNull()
+    })
+
     test('returns a previously persisted session when no fragment is present', () => {
-      localStorage.setItem('token', 'stored.jwt')
+      const token = fakeJwt()
+      localStorage.setItem('scc_dev_token', token)
       localStorage.setItem('scc_dev_channel', '999')
 
       const session = loadLocalDevSession()
 
-      expect(session).toEqual({ token: 'stored.jwt', channelId: '999' })
+      expect(session).toEqual({ token, channelId: '999', backend: null })
       expect(updateMockConfig).toHaveBeenCalledWith({ useRealServer: true })
       expect(connectPhoenixSocket).toHaveBeenCalled()
+    })
+
+    test('purges an expired session and stays on the mock harness', () => {
+      localStorage.setItem('scc_dev_token', expiredJwt())
+      localStorage.setItem('scc_dev_channel', '999')
+      localStorage.setItem('scc_dev_backend', 'https://staging.example.com')
+
+      const session = loadLocalDevSession()
+
+      expect(session).toBeNull()
+      expect(localStorage.getItem('scc_dev_token')).toBeNull()
+      expect(localStorage.getItem('scc_dev_channel')).toBeNull()
+      expect(localStorage.getItem('scc_dev_backend')).toBeNull()
+      expect(updateMockConfig).not.toHaveBeenCalled()
+      expect(connectPhoenixSocket).not.toHaveBeenCalled()
     })
 
     test('does nothing without a session', () => {
@@ -86,12 +146,12 @@ describe('localDevSession', () => {
 
     test('is inert outside development mode', () => {
       vi.stubEnv('MODE', 'production')
-      window.location.hash = '#scc_dev_token=jwt.abc.def&scc_dev_channel=12345'
+      window.location.hash = `#scc_dev_token=${fakeJwt()}&scc_dev_channel=12345`
 
       const session = loadLocalDevSession()
 
       expect(session).toBeNull()
-      expect(localStorage.getItem('token')).toBeNull()
+      expect(localStorage.getItem('scc_dev_token')).toBeNull()
       expect(updateMockConfig).not.toHaveBeenCalled()
     })
 
@@ -101,17 +161,17 @@ describe('localDevSession', () => {
       const session = loadLocalDevSession()
 
       expect(session).toBeNull()
-      expect(localStorage.getItem('token')).toBeNull()
+      expect(localStorage.getItem('scc_dev_token')).toBeNull()
       expect(localStorage.getItem('scc_dev_channel')).toBeNull()
     })
 
     test('clears a partial fragment without persisting a session', () => {
-      window.location.hash = '#scc_dev_token=jwt.abc.def'
+      window.location.hash = `#scc_dev_token=${fakeJwt()}`
 
       const session = loadLocalDevSession()
 
       expect(session).toBeNull()
-      expect(localStorage.getItem('token')).toBeNull()
+      expect(localStorage.getItem('scc_dev_token')).toBeNull()
       // The lone token is scrubbed from the address bar rather than left behind.
       expect(window.location.hash).toBe('')
     })
@@ -120,12 +180,19 @@ describe('localDevSession', () => {
   describe('hasLocalDevToken', () => {
     test('reflects whether a token is stored', () => {
       expect(hasLocalDevToken()).toBe(false)
-      localStorage.setItem('token', 'tok')
+      localStorage.setItem('scc_dev_token', fakeJwt())
       expect(hasLocalDevToken()).toBe(true)
     })
 
+    test('is false (and purges) when the stored token is expired', () => {
+      localStorage.setItem('scc_dev_token', expiredJwt())
+
+      expect(hasLocalDevToken()).toBe(false)
+      expect(localStorage.getItem('scc_dev_token')).toBeNull()
+    })
+
     test('is false outside development mode', () => {
-      localStorage.setItem('token', 'tok')
+      localStorage.setItem('scc_dev_token', fakeJwt())
       vi.stubEnv('MODE', 'production')
       expect(hasLocalDevToken()).toBe(false)
     })
@@ -133,7 +200,7 @@ describe('localDevSession', () => {
 
   describe('getLocalDevSession', () => {
     test('returns null when token or channel is missing', () => {
-      localStorage.setItem('token', 'only-token')
+      localStorage.setItem('scc_dev_token', fakeJwt())
       expect(getLocalDevSession()).toBeNull()
     })
   })
@@ -158,25 +225,62 @@ describe('localDevSession', () => {
 
   describe('clearLocalDevSession', () => {
     test('removes the session and returns to mocks', () => {
-      localStorage.setItem('token', 'stored.jwt')
+      localStorage.setItem('scc_dev_token', fakeJwt())
       localStorage.setItem('scc_dev_channel', '999')
+      localStorage.setItem('scc_dev_backend', 'https://staging.example.com')
 
       clearLocalDevSession()
 
-      expect(localStorage.getItem('token')).toBeNull()
+      expect(localStorage.getItem('scc_dev_token')).toBeNull()
       expect(localStorage.getItem('scc_dev_channel')).toBeNull()
+      expect(localStorage.getItem('scc_dev_backend')).toBeNull()
       expect(updateMockConfig).toHaveBeenCalledWith({ useRealServer: false })
       expect(disconnectPhoenixSocket).toHaveBeenCalled()
     })
 
-    test('is a no-op outside development mode (leaves the auth token intact)', () => {
-      vi.stubEnv('MODE', 'production')
+    test('never touches the primary auth token, even in dev mode', () => {
       localStorage.setItem('token', 'real-auth-token')
+      localStorage.setItem('scc_dev_token', fakeJwt())
+      localStorage.setItem('scc_dev_channel', '999')
 
       clearLocalDevSession()
 
       expect(localStorage.getItem('token')).toBe('real-auth-token')
+      expect(localStorage.getItem('scc_dev_token')).toBeNull()
+    })
+
+    test('is a no-op outside development mode', () => {
+      vi.stubEnv('MODE', 'production')
+      localStorage.setItem('scc_dev_token', 'anything')
+
+      clearLocalDevSession()
+
+      expect(localStorage.getItem('scc_dev_token')).toBe('anything')
       expect(updateMockConfig).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('backend URL derivation (devSessionStorage)', () => {
+    test('defaults to the production endpoints without a dev backend', () => {
+      expect(getSocketUrl()).toBe('wss://stream-cc.gooseman.codes/socket')
+      expect(getGraphqlUrl()).toBe('https://stream-cc.gooseman.codes/api')
+    })
+
+    test('derives ws/http URLs from the seeded backend origin', () => {
+      localStorage.setItem('scc_dev_backend', 'http://localhost:4000')
+      expect(getSocketUrl()).toBe('ws://localhost:4000/socket')
+      expect(getGraphqlUrl()).toBe('http://localhost:4000/api')
+
+      localStorage.setItem('scc_dev_backend', 'https://staging.example.com')
+      expect(getSocketUrl()).toBe('wss://staging.example.com/socket')
+    })
+
+    test('ignores the seeded backend outside development mode', () => {
+      localStorage.setItem('scc_dev_backend', 'http://localhost:4000')
+      vi.stubEnv('MODE', 'production')
+
+      expect(getSocketUrl()).toBe('wss://stream-cc.gooseman.codes/socket')
+      expect(getGraphqlUrl()).toBe('https://stream-cc.gooseman.codes/api')
     })
   })
 })

--- a/src/utils/__tests__/localDevSession.test.js
+++ b/src/utils/__tests__/localDevSession.test.js
@@ -22,6 +22,7 @@ import {
   loadLocalDevSession,
   setLocalDevChannel,
   clearLocalDevSession,
+  hasLocalDevToken,
 } from '../localDevSession'
 
 describe('localDevSession', () => {
@@ -102,6 +103,31 @@ describe('localDevSession', () => {
       expect(session).toBeNull()
       expect(localStorage.getItem('token')).toBeNull()
       expect(localStorage.getItem('scc_dev_channel')).toBeNull()
+    })
+
+    test('clears a partial fragment without persisting a session', () => {
+      window.location.hash = '#scc_dev_token=jwt.abc.def'
+
+      const session = loadLocalDevSession()
+
+      expect(session).toBeNull()
+      expect(localStorage.getItem('token')).toBeNull()
+      // The lone token is scrubbed from the address bar rather than left behind.
+      expect(window.location.hash).toBe('')
+    })
+  })
+
+  describe('hasLocalDevToken', () => {
+    test('reflects whether a token is stored', () => {
+      expect(hasLocalDevToken()).toBe(false)
+      localStorage.setItem('token', 'tok')
+      expect(hasLocalDevToken()).toBe(true)
+    })
+
+    test('is false outside development mode', () => {
+      localStorage.setItem('token', 'tok')
+      vi.stubEnv('MODE', 'production')
+      expect(hasLocalDevToken()).toBe(false)
     })
   })
 

--- a/src/utils/apollo.js
+++ b/src/utils/apollo.js
@@ -11,6 +11,7 @@ import * as AbsintheSocket from '@absinthe/socket'
 import { createAbsintheSocketLink } from '@absinthe/socket-apollo-link'
 import { Socket as PhoenixSocket } from 'phoenix'
 import { createMockLink, shouldUseRealServer } from './graphql-mocks'
+import { getDevToken, getSocketUrl, getGraphqlUrl } from './devSessionStorage'
 
 // Check if we're in development mode
 const isDevelopment = import.meta.env.MODE === 'development'
@@ -25,9 +26,12 @@ let absintheSocketLink = null
  */
 function initializePhoenixSocket() {
   if (!phxSocket) {
-    phxSocket = new PhoenixSocket('wss://stream-cc.gooseman.codes/socket', {
+    // getSocketUrl/getDevToken resolve to an admin-seeded dev session's
+    // backend + token in development, and to production + the regular auth
+    // token everywhere else.
+    phxSocket = new PhoenixSocket(getSocketUrl(), {
       params: () => {
-        const token = localStorage.getItem('token')
+        const token = getDevToken() || localStorage.getItem('token')
         if (token) {
           return { Authorization: `Bearer ${token}` }
         } else {
@@ -90,14 +94,19 @@ export function disconnectPhoenixSocket() {
 }
 
 const httpLink = createHttpLink({
-  uri: 'https://stream-cc.gooseman.codes/api',
+  // Resolved per request so a dev session can point at the deploy that
+  // minted it; outside development this is always the production endpoint.
+  uri: () => getGraphqlUrl(),
 })
 
 const authLink = setContext(({ operationName }, { headers }) => {
   // get the authentication token from local storage if it exists
   const tokenType =
     operationName === 'processBitsTransaction' ? 'transactionToken' : 'token'
-  const token = localStorage.getItem(tokenType)
+  // A dev-session token wins for regular queries; bits transactions keep
+  // using the Twitch-issued transaction token.
+  const token =
+    (tokenType === 'token' && getDevToken()) || localStorage.getItem(tokenType)
 
   // return the headers to the context so httpLink can read them
   return {

--- a/src/utils/devSessionStorage.js
+++ b/src/utils/devSessionStorage.js
@@ -1,0 +1,103 @@
+/**
+ * Storage keys and low-level accessors for the dev-only local testing session.
+ *
+ * Deliberately kept free of app imports (only the pure JWT decoder): both
+ * `apollo.js` (socket/auth plumbing) and `localDevSession.js` (session
+ * lifecycle) need these, and putting them anywhere else would create a module
+ * cycle.
+ *
+ * The dev session owns its own `scc_dev_*` localStorage keys so it can never
+ * be confused with — or delete — the primary auth token that
+ * `Authentication.setToken` stores under `'token'`.
+ */
+import { decodeJwtPayload } from './Authentication'
+
+export const DEV_TOKEN_KEY = 'scc_dev_token'
+export const DEV_CHANNEL_KEY = 'scc_dev_channel'
+export const DEV_BACKEND_KEY = 'scc_dev_backend'
+
+const DEFAULT_BACKEND_ORIGIN = 'https://stream-cc.gooseman.codes'
+
+/**
+ * Whether local dev tooling is active. Read lazily (not a module constant) so
+ * it reflects the current build mode and stays testable.
+ * @returns {boolean}
+ */
+export function isLocalDevEnabled() {
+  return import.meta.env.MODE === 'development'
+}
+
+/**
+ * The seeded dev socket token, or null when absent, expired, or not in dev
+ * mode. An expired token purges the whole stored session so the next boot
+ * falls back to the mock harness instead of a dead real-server connection.
+ * @returns {string|null}
+ */
+export function getDevToken() {
+  if (!isLocalDevEnabled()) {
+    return null
+  }
+
+  const token = localStorage.getItem(DEV_TOKEN_KEY)
+
+  if (!token) {
+    return null
+  }
+
+  if (isExpired(token)) {
+    clearDevSessionStorage()
+    return null
+  }
+
+  return token
+}
+
+/**
+ * The backend origin the dev session was minted by (e.g. a staging deploy),
+ * or null to use the production default.
+ * @returns {string|null}
+ */
+export function getDevBackendOrigin() {
+  if (!isLocalDevEnabled()) {
+    return null
+  }
+
+  return localStorage.getItem(DEV_BACKEND_KEY)
+}
+
+/**
+ * Websocket URL for the dev session's backend, or the production default.
+ * @returns {string}
+ */
+export function getSocketUrl() {
+  const origin = getDevBackendOrigin() || DEFAULT_BACKEND_ORIGIN
+  return `${origin.replace(/^http/, 'ws')}/socket`
+}
+
+/**
+ * GraphQL HTTP endpoint for the dev session's backend, or the production
+ * default.
+ * @returns {string}
+ */
+export function getGraphqlUrl() {
+  const origin = getDevBackendOrigin() || DEFAULT_BACKEND_ORIGIN
+  return `${origin}/api`
+}
+
+/** Remove every stored dev-session key (never touches the 'token' key). */
+export function clearDevSessionStorage() {
+  localStorage.removeItem(DEV_TOKEN_KEY)
+  localStorage.removeItem(DEV_CHANNEL_KEY)
+  localStorage.removeItem(DEV_BACKEND_KEY)
+}
+
+function isExpired(token) {
+  try {
+    const { exp } = decodeJwtPayload(token)
+    return Boolean(exp) && exp * 1000 <= Date.now()
+  } catch (_e) {
+    // Unreadable tokens can't authenticate anyway — purge rather than boot
+    // into a real-server session that silently shows no captions.
+    return true
+  }
+}

--- a/src/utils/localDevSession.js
+++ b/src/utils/localDevSession.js
@@ -5,11 +5,16 @@
  * a real, currently-live broadcaster's captions in order to validate that
  * extension changes didn't break anything.
  *
- * The token + channel id are minted/listed by the admin-only "Local Extension
- * Testing" page on the backend (restricted to the owner account) and handed to
- * the local build through the URL fragment, e.g.:
+ * The token, channel id, and backend origin are minted/listed by the
+ * admin-only "Local Extension Testing" page on the backend (restricted to the
+ * owner account) and handed to the local build through the URL fragment, e.g.:
  *
- *   http://localhost:8080/?anchor=video_overlay#scc_dev_token=<jwt>&scc_dev_channel=<uid>
+ *   http://localhost:8080/?anchor=video_overlay&platform=web#scc_dev_token=<jwt>&scc_dev_channel=<uid>&scc_dev_backend=<origin>
+ *
+ * The session lives under its own `scc_dev_*` localStorage keys (see
+ * `devSessionStorage.js`) so it can never collide with the primary auth token
+ * the Twitch host stores under `'token'`. Expired tokens are purged on read,
+ * falling back to the mock harness.
  *
  * Every entry point is gated on `import.meta.env.MODE === 'development'`, so the
  * behavior is inert in production builds (the same approach the existing mock
@@ -21,20 +26,17 @@ import {
   connectPhoenixSocket,
   disconnectPhoenixSocket,
 } from './apollo'
+import {
+  DEV_TOKEN_KEY,
+  DEV_CHANNEL_KEY,
+  DEV_BACKEND_KEY,
+  isLocalDevEnabled,
+  getDevToken,
+  getDevBackendOrigin,
+  clearDevSessionStorage,
+} from './devSessionStorage'
 
-const TOKEN_KEY = 'token'
-const CHANNEL_KEY = 'scc_dev_channel'
-const HASH_TOKEN_KEY = 'scc_dev_token'
-const HASH_CHANNEL_KEY = 'scc_dev_channel'
-
-/**
- * Whether local dev tooling is active. Read lazily (not a module constant) so
- * it reflects the current build mode and stays testable.
- * @returns {boolean}
- */
-export function isLocalDevEnabled() {
-  return import.meta.env.MODE === 'development'
-}
+export { isLocalDevEnabled }
 
 function parseHashParams() {
   const hash = window.location?.hash || ''
@@ -54,29 +56,30 @@ function stripHash() {
 
 /**
  * Read a dev session that's already persisted in localStorage.
- * @returns {{token: string, channelId: string}|null}
+ * @returns {{token: string, channelId: string, backend: string|null}|null}
  */
 export function getLocalDevSession() {
-  if (!isLocalDevEnabled()) {
+  const token = getDevToken()
+
+  if (!token) {
     return null
   }
 
-  const token = localStorage.getItem(TOKEN_KEY)
-  const channelId = localStorage.getItem(CHANNEL_KEY)
+  const channelId = localStorage.getItem(DEV_CHANNEL_KEY)
 
-  if (token && channelId) {
-    return { token, channelId }
+  if (!channelId) {
+    return null
   }
 
-  return null
+  return { token, channelId, backend: getDevBackendOrigin() }
 }
 
 /**
- * Boot-time entry point (called from `useTwitchAuth` when there's no Twitch
- * host). Seeds a session from the URL fragment if present, then, if a session
- * exists, switches Apollo to the real backend and opens the websocket.
+ * Boot-time entry point (called from `useTwitchAuth` before deferring to the
+ * Twitch host). Seeds a session from the URL fragment if present, then, if a
+ * session exists, switches Apollo to the real backend and opens the websocket.
  *
- * @returns {{token: string, channelId: string}|null} active session, if any
+ * @returns {{token: string, channelId: string, backend: string|null}|null}
  */
 export function loadLocalDevSession() {
   if (!isLocalDevEnabled()) {
@@ -84,16 +87,25 @@ export function loadLocalDevSession() {
   }
 
   const params = parseHashParams()
-  const hashToken = (params.get(HASH_TOKEN_KEY) || '').trim()
-  const hashChannel = (params.get(HASH_CHANNEL_KEY) || '').trim()
+  const hashToken = (params.get(DEV_TOKEN_KEY) || '').trim()
+  const hashChannel = (params.get(DEV_CHANNEL_KEY) || '').trim()
+  const hashBackend = (params.get(DEV_BACKEND_KEY) || '').trim()
 
-  // Clear the fragment whenever either dev-session param carries a value (so a
+  // Clear the fragment whenever any dev-session param carries a value (so a
   // lone token can't linger in the address bar), but only persist a session
-  // when both are present.
-  if (hashToken || hashChannel) {
+  // when both token and channel are present.
+  if (hashToken || hashChannel || hashBackend) {
     if (hashToken && hashChannel) {
-      localStorage.setItem(TOKEN_KEY, hashToken)
-      localStorage.setItem(CHANNEL_KEY, hashChannel)
+      localStorage.setItem(DEV_TOKEN_KEY, hashToken)
+      localStorage.setItem(DEV_CHANNEL_KEY, hashChannel)
+
+      // A stale backend from a previous session must not outlive the session
+      // that owned it, so an absent param clears the override.
+      if (hashBackend) {
+        localStorage.setItem(DEV_BACKEND_KEY, hashBackend)
+      } else {
+        localStorage.removeItem(DEV_BACKEND_KEY)
+      }
     }
 
     stripHash()
@@ -113,12 +125,12 @@ export function loadLocalDevSession() {
 }
 
 /**
- * Whether a socket token has already been seeded (via an admin link). Switching
- * channels in the dev dialog only works once a token exists.
+ * Whether a (non-expired) socket token has already been seeded via an admin
+ * link. Switching channels in the dev dialog only works once a token exists.
  * @returns {boolean}
  */
 export function hasLocalDevToken() {
-  return isLocalDevEnabled() && Boolean(localStorage.getItem(TOKEN_KEY))
+  return Boolean(getDevToken())
 }
 
 /**
@@ -134,23 +146,22 @@ export function setLocalDevChannel(channelId) {
   const trimmed = (channelId || '').trim()
 
   if (trimmed) {
-    localStorage.setItem(CHANNEL_KEY, trimmed)
+    localStorage.setItem(DEV_CHANNEL_KEY, trimmed)
   }
 }
 
 /**
  * Tear down the dev session and return to the mock harness. No-op outside
- * development so the primary auth token is never touched in production.
- * Also closes the websocket so live captions stop flowing even if the caller
- * doesn't immediately reload the page.
+ * development; only the dev session's own `scc_dev_*` keys are removed, so the
+ * primary auth token is never touched. Also closes the websocket so live
+ * captions stop flowing even if the caller doesn't immediately reload.
  */
 export function clearLocalDevSession() {
   if (!isLocalDevEnabled()) {
     return
   }
 
-  localStorage.removeItem(TOKEN_KEY)
-  localStorage.removeItem(CHANNEL_KEY)
+  clearDevSessionStorage()
   updateMockConfig({ useRealServer: false })
   disconnectPhoenixSocket()
 }

--- a/src/utils/localDevSession.js
+++ b/src/utils/localDevSession.js
@@ -1,0 +1,120 @@
+/**
+ * Dev-only "local extension testing" session.
+ *
+ * Lets the maintainer run this front end locally (`yarn start`) and connect to
+ * a real, currently-live broadcaster's captions in order to validate that
+ * extension changes didn't break anything.
+ *
+ * The token + channel id are minted/listed by the admin-only "Local Extension
+ * Testing" page on the backend (restricted to the owner account) and handed to
+ * the local build through the URL fragment, e.g.:
+ *
+ *   http://localhost:8080/?anchor=video_overlay#scc_dev_token=<jwt>&scc_dev_channel=<uid>
+ *
+ * None of this is reachable in a production build: every entry point is gated
+ * on `import.meta.env.MODE === 'development'`, so the shipped Twitch extension
+ * bundle never includes the behavior.
+ */
+import { updateMockConfig } from './graphql-mocks'
+import { initializePhoenixSocket, connectPhoenixSocket } from './apollo'
+
+const TOKEN_KEY = 'token'
+const CHANNEL_KEY = 'scc_dev_channel'
+const HASH_TOKEN_KEY = 'scc_dev_token'
+const HASH_CHANNEL_KEY = 'scc_dev_channel'
+
+/**
+ * Whether local dev tooling is active. Read lazily (not a module constant) so
+ * it reflects the current build mode and stays testable.
+ * @returns {boolean}
+ */
+export function isLocalDevEnabled() {
+  return import.meta.env.MODE === 'development'
+}
+
+function parseHashParams() {
+  const hash = window.location?.hash || ''
+  return new URLSearchParams(hash.replace(/^#/, ''))
+}
+
+/**
+ * Remove the fragment from the address bar so the token isn't left lingering
+ * in the URL after we've persisted it.
+ */
+function stripHash() {
+  if (typeof window.history?.replaceState === 'function') {
+    const { pathname, search } = window.location
+    window.history.replaceState(null, '', `${pathname}${search}`)
+  }
+}
+
+/**
+ * Read a dev session that's already persisted in localStorage.
+ * @returns {{token: string, channelId: string}|null}
+ */
+export function getLocalDevSession() {
+  if (!isLocalDevEnabled()) {
+    return null
+  }
+
+  const token = localStorage.getItem(TOKEN_KEY)
+  const channelId = localStorage.getItem(CHANNEL_KEY)
+
+  if (token && channelId) {
+    return { token, channelId }
+  }
+
+  return null
+}
+
+/**
+ * Boot-time entry point (called from `useTwitchAuth` when there's no Twitch
+ * host). Seeds a session from the URL fragment if present, then, if a session
+ * exists, switches Apollo to the real backend and opens the websocket.
+ *
+ * @returns {{token: string, channelId: string}|null} active session, if any
+ */
+export function loadLocalDevSession() {
+  if (!isLocalDevEnabled()) {
+    return null
+  }
+
+  const params = parseHashParams()
+  const hashToken = params.get(HASH_TOKEN_KEY)
+  const hashChannel = params.get(HASH_CHANNEL_KEY)
+
+  if (hashToken && hashChannel) {
+    localStorage.setItem(TOKEN_KEY, hashToken)
+    localStorage.setItem(CHANNEL_KEY, hashChannel)
+    stripHash()
+  }
+
+  const session = getLocalDevSession()
+
+  if (session) {
+    // Bypass the mock harness and talk to the real backend, then make sure the
+    // socket exists and is connected before the caption subscription runs.
+    updateMockConfig({ useRealServer: true })
+    initializePhoenixSocket()
+    connectPhoenixSocket()
+  }
+
+  return session
+}
+
+/**
+ * Point the local build at a different live channel (reusing the stored token).
+ * @param {string} channelId
+ */
+export function setLocalDevChannel(channelId) {
+  localStorage.setItem(CHANNEL_KEY, channelId)
+}
+
+/**
+ * Tear down the dev session and return to the mock harness.
+ */
+export function clearLocalDevSession() {
+  localStorage.removeItem(TOKEN_KEY)
+  localStorage.removeItem(CHANNEL_KEY)
+  updateMockConfig({ useRealServer: false })
+}

--- a/src/utils/localDevSession.js
+++ b/src/utils/localDevSession.js
@@ -11,12 +11,16 @@
  *
  *   http://localhost:8080/?anchor=video_overlay#scc_dev_token=<jwt>&scc_dev_channel=<uid>
  *
- * None of this is reachable in a production build: every entry point is gated
- * on `import.meta.env.MODE === 'development'`, so the shipped Twitch extension
- * bundle never includes the behavior.
+ * Every entry point is gated on `import.meta.env.MODE === 'development'`, so the
+ * behavior is inert in production builds (the same approach the existing mock
+ * harness uses). The module may still be bundled, but it never runs outside dev.
  */
 import { updateMockConfig } from './graphql-mocks'
-import { initializePhoenixSocket, connectPhoenixSocket } from './apollo'
+import {
+  initializePhoenixSocket,
+  connectPhoenixSocket,
+  disconnectPhoenixSocket,
+} from './apollo'
 
 const TOKEN_KEY = 'token'
 const CHANNEL_KEY = 'scc_dev_channel'
@@ -124,6 +128,8 @@ export function setLocalDevChannel(channelId) {
 /**
  * Tear down the dev session and return to the mock harness. No-op outside
  * development so the primary auth token is never touched in production.
+ * Also closes the websocket so live captions stop flowing even if the caller
+ * doesn't immediately reload the page.
  */
 export function clearLocalDevSession() {
   if (!isLocalDevEnabled()) {
@@ -133,4 +139,5 @@ export function clearLocalDevSession() {
   localStorage.removeItem(TOKEN_KEY)
   localStorage.removeItem(CHANNEL_KEY)
   updateMockConfig({ useRealServer: false })
+  disconnectPhoenixSocket()
 }

--- a/src/utils/localDevSession.js
+++ b/src/utils/localDevSession.js
@@ -80,9 +80,11 @@ export function loadLocalDevSession() {
   }
 
   const params = parseHashParams()
-  const hashToken = params.get(HASH_TOKEN_KEY)
-  const hashChannel = params.get(HASH_CHANNEL_KEY)
+  const hashToken = (params.get(HASH_TOKEN_KEY) || '').trim()
+  const hashChannel = (params.get(HASH_CHANNEL_KEY) || '').trim()
 
+  // Only persist (and clear the fragment) when both values are actually present
+  // after trimming, so stray whitespace can't leave a broken session behind.
   if (hashToken && hashChannel) {
     localStorage.setItem(TOKEN_KEY, hashToken)
     localStorage.setItem(CHANNEL_KEY, hashChannel)
@@ -104,16 +106,30 @@ export function loadLocalDevSession() {
 
 /**
  * Point the local build at a different live channel (reusing the stored token).
+ * No-op outside development, and ignores empty/whitespace input.
  * @param {string} channelId
  */
 export function setLocalDevChannel(channelId) {
-  localStorage.setItem(CHANNEL_KEY, channelId)
+  if (!isLocalDevEnabled()) {
+    return
+  }
+
+  const trimmed = (channelId || '').trim()
+
+  if (trimmed) {
+    localStorage.setItem(CHANNEL_KEY, trimmed)
+  }
 }
 
 /**
- * Tear down the dev session and return to the mock harness.
+ * Tear down the dev session and return to the mock harness. No-op outside
+ * development so the primary auth token is never touched in production.
  */
 export function clearLocalDevSession() {
+  if (!isLocalDevEnabled()) {
+    return
+  }
+
   localStorage.removeItem(TOKEN_KEY)
   localStorage.removeItem(CHANNEL_KEY)
   updateMockConfig({ useRealServer: false })

--- a/src/utils/localDevSession.js
+++ b/src/utils/localDevSession.js
@@ -87,11 +87,15 @@ export function loadLocalDevSession() {
   const hashToken = (params.get(HASH_TOKEN_KEY) || '').trim()
   const hashChannel = (params.get(HASH_CHANNEL_KEY) || '').trim()
 
-  // Only persist (and clear the fragment) when both values are actually present
-  // after trimming, so stray whitespace can't leave a broken session behind.
-  if (hashToken && hashChannel) {
-    localStorage.setItem(TOKEN_KEY, hashToken)
-    localStorage.setItem(CHANNEL_KEY, hashChannel)
+  // Clear the fragment whenever either dev-session param carries a value (so a
+  // lone token can't linger in the address bar), but only persist a session
+  // when both are present.
+  if (hashToken || hashChannel) {
+    if (hashToken && hashChannel) {
+      localStorage.setItem(TOKEN_KEY, hashToken)
+      localStorage.setItem(CHANNEL_KEY, hashChannel)
+    }
+
     stripHash()
   }
 
@@ -106,6 +110,15 @@ export function loadLocalDevSession() {
   }
 
   return session
+}
+
+/**
+ * Whether a socket token has already been seeded (via an admin link). Switching
+ * channels in the dev dialog only works once a token exists.
+ * @returns {boolean}
+ */
+export function hasLocalDevToken() {
+  return isLocalDevEnabled() && Boolean(localStorage.getItem(TOKEN_KEY))
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR adds a development-only feature that allows maintainers to run the extension locally and connect to real, live broadcaster captions for validation testing. Every entry point is gated on the development build mode, so the feature is inert in production builds.

## Key Changes

- **New `localDevSession.js` utility** (`src/utils/localDevSession.js`):
  - Reads dev session credentials (JWT token + channel ID) from URL fragment
  - Persists credentials to localStorage for reuse across page reloads
  - Provides functions to load, switch, and clear dev sessions
  - All functionality is gated on `import.meta.env.MODE === 'development'`

- **Enhanced `useTwitchAuth` hook** (`src/hooks/useTwitchAuth.js`):
  - Synthesizes a Twitch-style auth object from local dev session when running outside the Twitch host
  - Uses a plausible owner account ID for the synthesized auth (backend trusts the JWT, not this value)
  - Allows normal caption subscription flow to run unchanged

- **Updated `DevMockControlsDialog` component** (`src/components/DevMockControlsDialog/DevMockControlsDialog.jsx`):
  - Added "Live Channel (Dev)" section to the mock controls dialog
  - Allows switching between live channels by entering a channel ID
  - Shows current connected channel status
  - Provides disconnect button to return to mock harness

- **Comprehensive test coverage** (`src/utils/__tests__/localDevSession.test.js` and updated `useTwitchAuth.test.jsx`):
  - Tests for all dev session functions
  - Tests for auth synthesis from dev sessions
  - Verifies production mode safety

- **Updated README** with setup and usage instructions for local testing against live captions

## Implementation Details

- The URL fragment containing the token is stripped from the address bar after being read to prevent the token from lingering
- Dev sessions are persisted in localStorage, allowing reuse without revisiting the admin page
- Switching channels triggers a page reload to reconnect the websocket with the new subscription
- The backend must have `LOCAL_EXT_TESTING_ORIGINS` env var configured to accept connections from local origins
- All entry points are guarded by `isLocalDevEnabled()` checks (dev-mode-gated; the module may still be bundled but never runs outside development), ensuring zero production impact

https://claude.ai/code/session_011ovpeFMYVZ9RJBUWYfuxG3