### PR TITLE
Add pre-release workflow for automated development builds

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -8,13 +8,20 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: pre-release-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-release:
     name: "Pre Release"
     runs-on: "ubuntu-latest"
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -24,12 +31,12 @@ jobs:
       - run: yarn test
       - run: yarn build
       - name: Zip Release Build
-        uses: thedoctor0/zip-release@main
+        uses: thedoctor0/zip-release@0.7.6
         with:
           type: 'zip'
           filename: 'release.zip'
           directory: 'dist/'
-      - uses: "marvinpinto/action-automatic-releases@latest"
+      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,39 @@
+name: "pre-release"
+
+on:
+  push:
+    branches:
+      - "main"
+
+permissions:
+  contents: write
+
+jobs:
+  pre-release:
+    name: "Pre Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+      - run: yarn test
+      - run: yarn build
+      - name: Zip Release Build
+        uses: thedoctor0/zip-release@main
+        with:
+          type: 'zip'
+          filename: 'release.zip'
+          directory: 'dist/'
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Development Build"
+          files: |
+            dist/release.zip


### PR DESCRIPTION
## Summary
This PR introduces a GitHub Actions workflow that automatically creates pre-release builds whenever code is pushed to the main branch.

## Key Changes
- Added `.github/workflows/pre-release.yml` workflow that:
  - Triggers on every push to the main branch
  - Runs linting and tests to ensure code quality
  - Builds the project
  - Packages the dist directory into a zip file
  - Creates an automatic pre-release on GitHub with the built artifacts

## Implementation Details
- Uses Node.js 22 with yarn for dependency management
- Installs dependencies with `--frozen-lockfile` for reproducible builds
- Runs the full CI pipeline (lint, test, build) before creating the release
- Automatically tags releases as "latest" and marks them as pre-releases
- Attaches the built `release.zip` file to each pre-release for easy distribution
- Uses `GITHUB_TOKEN` for authentication to create releases

https://claude.ai/code/session_01NtnQ9f99Nhx7xFV95L7fuh