### PR TITLE
Add co-streamer guest caption support

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "memory": {
+      "type": "http",
+      "url": "${WINDMILL_MCP_URL}",
+      "headers": {
+        "Authorization": "Bearer ${WINDMILL_MCP_TOKEN}"
+      }
+    }
+  }
+}

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -3,10 +3,36 @@
 # Active Context
 
 ## Current Status
-**Phase 3: Performance Optimization Complete** - All 3 sub-phases implemented, tested, and verified
+**Co-Streamer Guest Captions implemented** (2026-07-12, branch
+`claude/costreamer-captions-stcu3m`) — pending extension version release;
+backend counterpart lives in `stream_closed_captioner_phoenix` on the same
+branch (feature-flag gated there).
 **Repository:** Production-ready with modern tooling, comprehensive tests, zero linting issues, and optimized performance
 
-## What Just Changed (Phase 3)
+## What Just Changed (Co-Streamer Guest Captions)
+
+- New `newCostreamCaption(channelId)` subscription consumed alongside
+  `newTwitchCaption` (`graphql.js`, `subscribeToCostreamCaptions` thunk with
+  the same hlsLatency delay). Kept separate on the backend on purpose: old
+  bundles' hardcoded `newTwitchCaption` query never carries guest text, so
+  released versions are structurally unaffected.
+- `captions-slice`: guest finals land in the shared `finalTextQueue` tagged
+  `{ guestId, name }` for chronological interleave; dedupe is now
+  **per speaker** (`lastEntryFor`) so interleaved lines can't defeat repeat
+  suppression. New `costreamInterim` map (guestId → { name, text }).
+- Render: `assembleCaptionLines` takes an options arg (`showCostream`,
+  `showCostreamInTranslatedView`); guest lines render name-prefixed
+  ("Alice: …"); translated views append guests' untranslated originals after
+  translated lines (guests are never translated). `CaptionBody` gained
+  `costreamInterimLines`.
+- Settings: `showCostreamCaptions` (default ON) + translated-view sub-toggle,
+  both **persisted to localStorage** via new `utils/viewer-prefs.js` — first
+  persisted viewer settings in the extension. Gear-menu item:
+  `CostreamCaptionsOptionButton`.
+- Tests: 427 passing (new: `costreamCaptions`, `costreamSettings`,
+  `costream-helpers`).
+
+## Previously Changed (Phase 3)
 
 ### Phase 3a: Font Optimization ✅
 - Added `font-display: swap` to App.css for non-blocking font loading

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -110,8 +110,20 @@ Three-phase optimization for bundle size and React render efficiency
 - Total uncompressed: 2,293 → 1,994.7 kB (-13%)
 - Better caching and parallelization with split chunks
 
+### Co-Streamer Guest Captions ✅ COMPLETED (2026-07-12)
+- Separate `newCostreamCaption` subscription (backwards compatible by design —
+  old bundles never see guest text)
+- Speaker-tagged shared caption queue with per-speaker dedupe; per-guest
+  interim lines; name-prefixed rendering on overlay + mobile/panel
+- Viewer toggles: master show/hide (default on) + translated-view sub-toggle,
+  persisted to localStorage (`utils/viewer-prefs.js`)
+- 427 tests passing, lint clean, vite build verified
+- Ships with the `stream_closed_captioner_phoenix` costream backend
+  (flag-gated); needs a new extension version release to reach viewers
+
 ## In Progress
 - Nothing - All phases complete / Repository production-ready
 
 ## Remaining
+- Release new extension version with co-streamer caption support
 - Future enhancements based on product requirements

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -8,3 +8,18 @@
 ## Conventions
 - Index files export public APIs from folders.
 - Tests colocated in __tests__ folders.
+
+## Caption Data Model
+- `captionsState.finalTextQueue` is a single chronological feed shared by the
+  broadcaster and co-streamer guests. Broadcaster entries are `{ id, text }`;
+  guest entries add `{ guestId, name }` and render name-prefixed. Dedupe of
+  repeated finals is per speaker (`lastEntryFor`), never against the raw last
+  entry — interleaved speakers must not defeat repeat suppression.
+- Guest interim text lives in `captionsState.costreamInterim`
+  (guestId → { name, text }), separate from the broadcaster's `interimText`.
+- Guest captions arrive on the dedicated `newCostreamCaption` subscription.
+  Never move guest text onto `newTwitchCaption` — released bundles hardcode
+  that query and would render guests' words unattributed as the broadcaster's.
+- Viewer preferences that must survive reloads (currently the co-streamer
+  visibility toggles) persist via `src/utils/viewer-prefs.js` (localStorage,
+  best-effort); all other settings-slice state is intentionally in-memory.

--- a/src/Twitch.jsx
+++ b/src/Twitch.jsx
@@ -14,6 +14,7 @@ import { updateBroadcasterSettings } from '@/redux/settings-slice'
 import {
   stopCaptionsSubscription,
   subscribeToCaptions,
+  subscribeToCostreamCaptions,
 } from '@/redux/captions-slice'
 import { updateVideoPlayerContext } from '@/redux/video-player-context-slice'
 import {
@@ -58,7 +59,13 @@ export const Twitch = memo(function Twitch({ children }) {
     [dispatch],
   )
   const subscribeCaptions = useCallback(
-    (channelId) => dispatch(subscribeToCaptions(channelId)),
+    (channelId) => {
+      dispatch(subscribeToCaptions(channelId))
+      // Guest (co-streamer) captions arrive on their own subscription; the
+      // viewer's show/hide toggle is applied at render time so flipping it
+      // doesn't churn the socket.
+      dispatch(subscribeToCostreamCaptions(channelId))
+    },
     [dispatch],
   )
 

--- a/src/Twitch.jsx
+++ b/src/Twitch.jsx
@@ -12,7 +12,7 @@ import Authentication from './utils/Authentication'
 
 import { updateBroadcasterSettings } from '@/redux/settings-slice'
 import {
-  stopCaptionsSubscription,
+  stopCaptions,
   subscribeToCaptions,
   subscribeToCostreamCaptions,
 } from '@/redux/captions-slice'
@@ -111,7 +111,7 @@ export const Twitch = memo(function Twitch({ children }) {
 
   useEffect(() => {
     if (isCaptionsHidden && isVideoOverlay()) {
-      dispatch(stopCaptionsSubscription())
+      dispatch(stopCaptions())
     } else {
       subscribeCaptions(channelId)
     }

--- a/src/Twitch.jsx
+++ b/src/Twitch.jsx
@@ -60,6 +60,10 @@ export const Twitch = memo(function Twitch({ children }) {
   )
   const subscribeCaptions = useCallback(
     (channelId) => {
+      // The subscribing effect can fire before Twitch auth resolves;
+      // subscribing without a channelId just produces GraphQL errors/retries.
+      if (isNil(channelId) || isEmpty(channelId)) return
+
       dispatch(subscribeToCaptions(channelId))
       // Guest (co-streamer) captions arrive on their own subscription; the
       // viewer's show/hide toggle is applied at render time so flipping it

--- a/src/components/Captions/CaptionBody.jsx
+++ b/src/components/Captions/CaptionBody.jsx
@@ -19,6 +19,7 @@ function CaptionBody({
   captionText,
   grayOutFinalText,
   interimText,
+  costreamInterimLines = [],
 }) {
   return (
     <>
@@ -36,6 +37,11 @@ function CaptionBody({
           {interimText}
         </CaptionText>
       )}
+      {costreamInterimLines.map((line) => (
+        <CaptionText key={line.id} $block={rollUpCaptions} $interim>
+          {line.text}
+        </CaptionText>
+      ))}
     </>
   )
 }
@@ -51,6 +57,12 @@ CaptionBody.propTypes = {
   captionText: PropTypes.string.isRequired,
   grayOutFinalText: PropTypes.bool,
   interimText: PropTypes.string,
+  costreamInterimLines: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired,
+    }),
+  ),
 }
 
 export default CaptionBody

--- a/src/components/Captions/ClosedCaption.jsx
+++ b/src/components/Captions/ClosedCaption.jsx
@@ -8,6 +8,7 @@ import './ClosedCaption.css'
 import CaptionBody from './CaptionBody'
 import {
   assembleCaptionLines,
+  assembleCostreamInterimLines,
   getFontSizeStyle,
   isCaptionsHidden,
   joinCaptionLines,
@@ -36,9 +37,8 @@ function ClosedCaption() {
   const configSettings = useShallowEqualSelector(
     (state) => state.configSettings,
   )
-  const { interimText, finalTextQueue, translations } = useShallowEqualSelector(
-    (state) => state.captionsState,
-  )
+  const { interimText, finalTextQueue, translations, costreamInterim } =
+    useShallowEqualSelector((state) => state.captionsState)
   const onDragged = useCallback(() => dispatch(setIsDragged()), [dispatch])
   const fontSize = getFontSizeStyle(configSettings.size)
   const fontFamily = configSettings.dyslexiaFontEnabled
@@ -58,6 +58,10 @@ function ClosedCaption() {
     configSettings.viewerLanguage,
     finalTextQueue,
     translations,
+    {
+      showCostream: configSettings.showCostreamCaptions,
+      showCostreamInTranslatedView: configSettings.showCostreamInTranslatedView,
+    },
   )
   const finalTextCaptions = joinCaptionLines(captionLines)
   // Roll-up (line-per-sentence) is the default; viewers can opt back into the
@@ -68,10 +72,20 @@ function ClosedCaption() {
   // shows and for keeping the box visible.
   const interimVisible =
     configSettings.viewerLanguage === 'default' ? interimText || '' : ''
+  // Guest interim lines follow the viewer's costream toggles; guests' interim
+  // is original-language text, so in a translated view it obeys the same
+  // show-originals choice as their final lines.
+  const costreamInterimVisible =
+    configSettings.showCostreamCaptions &&
+    (configSettings.viewerLanguage === 'default' ||
+      configSettings.showCostreamInTranslatedView)
+  const costreamInterimLines = costreamInterimVisible
+    ? assembleCostreamInterimLines(costreamInterim)
+    : []
   const isHidden = isCaptionsHidden(
     configSettings.hideCC,
     finalTextCaptions,
-    interimVisible,
+    interimVisible || costreamInterimLines[0]?.text || '',
   )
 
   return (
@@ -96,6 +110,7 @@ function ClosedCaption() {
             captionText={finalTextCaptions}
             grayOutFinalText={configSettings.grayOutFinalText}
             interimText={interimVisible}
+            costreamInterimLines={costreamInterimLines}
           />
         </Captions>
       </CaptionsContainer>

--- a/src/components/Captions/MobileClosedCaption.jsx
+++ b/src/components/Captions/MobileClosedCaption.jsx
@@ -3,6 +3,7 @@ import { Captions, CaptionsContainer } from '../shared/caption-styles'
 import CaptionBody from './CaptionBody'
 import {
   assembleCaptionLines,
+  assembleCostreamInterimLines,
   getMobileFontSizeStyle,
   joinCaptionLines,
 } from './helpers'
@@ -24,9 +25,8 @@ import { memo } from 'react'
 // Resub - CreativeBuilds
 
 function MobileClosedCaption() {
-  const { interimText, finalTextQueue, translations } = useShallowEqualSelector(
-    (state) => state.captionsState,
-  )
+  const { interimText, finalTextQueue, translations, costreamInterim } =
+    useShallowEqualSelector((state) => state.captionsState)
   const configSettings = useShallowEqualSelector(
     (state) => state.configSettings,
   )
@@ -44,11 +44,22 @@ function MobileClosedCaption() {
     configSettings.viewerLanguage,
     finalTextQueue,
     translations,
+    {
+      showCostream: configSettings.showCostreamCaptions,
+      showCostreamInTranslatedView: configSettings.showCostreamInTranslatedView,
+    },
   )
   const finalTextCaptions = joinCaptionLines(captionLines)
   // Interim text only renders for the default language; resolve to '' otherwise.
   const interimVisible =
     configSettings.viewerLanguage === 'default' ? interimText || '' : ''
+  const costreamInterimVisible =
+    configSettings.showCostreamCaptions &&
+    (configSettings.viewerLanguage === 'default' ||
+      configSettings.showCostreamInTranslatedView)
+  const costreamInterimLines = costreamInterimVisible
+    ? assembleCostreamInterimLines(costreamInterim)
+    : []
 
   return (
     <CaptionsContainer
@@ -66,6 +77,7 @@ function MobileClosedCaption() {
           captionText={finalTextCaptions}
           grayOutFinalText={configSettings.grayOutFinalText}
           interimText={interimVisible}
+          costreamInterimLines={costreamInterimLines}
         />
       </Captions>
     </CaptionsContainer>

--- a/src/components/Captions/__tests__/costream-helpers.test.js
+++ b/src/components/Captions/__tests__/costream-helpers.test.js
@@ -1,0 +1,84 @@
+import { assembleCaptionLines, assembleCostreamInterimLines } from '../helpers'
+
+const queue = [
+  { id: 'a', text: 'hello from the host' },
+  { id: 'b', guestId: '1', name: 'Alice', text: 'hi from alice' },
+  { id: 'c', text: 'host again' },
+]
+
+const translations = {
+  es: {
+    name: 'Spanish',
+    textQueue: [{ id: 't1', text: 'hola del anfitrión' }],
+  },
+}
+
+describe('assembleCaptionLines with co-streamers', () => {
+  test('default language interleaves guest lines name-prefixed', () => {
+    const lines = assembleCaptionLines('default', queue, {}, {})
+
+    expect(lines.map(({ text }) => text)).toStrictEqual([
+      'Hello from the host.',
+      'Alice: Hi from alice.',
+      'Host again.',
+    ])
+  })
+
+  test('guest lines are hidden when showCostream is false', () => {
+    const lines = assembleCaptionLines(
+      'default',
+      queue,
+      {},
+      {
+        showCostream: false,
+      },
+    )
+
+    expect(lines.map(({ text }) => text)).toStrictEqual([
+      'Hello from the host.',
+      'Host again.',
+    ])
+  })
+
+  test('defaults to showing guests when no options are passed (old call sites)', () => {
+    const lines = assembleCaptionLines('default', queue, {})
+
+    expect(lines).toHaveLength(3)
+  })
+
+  test('translated view appends guest originals after translated lines', () => {
+    const lines = assembleCaptionLines('es', queue, translations, {
+      showCostream: true,
+      showCostreamInTranslatedView: true,
+    })
+
+    expect(lines.map(({ text }) => text)).toStrictEqual([
+      'Hola del anfitrión.',
+      'Alice: Hi from alice.',
+    ])
+  })
+
+  test('translated view hides guests when the sub-toggle is off', () => {
+    const lines = assembleCaptionLines('es', queue, translations, {
+      showCostream: true,
+      showCostreamInTranslatedView: false,
+    })
+
+    expect(lines.map(({ text }) => text)).toStrictEqual(['Hola del anfitrión.'])
+  })
+})
+
+describe('assembleCostreamInterimLines', () => {
+  test('builds name-prefixed interim lines and drops empty ones', () => {
+    const lines = assembleCostreamInterimLines({
+      1: { name: 'Alice', text: 'still talk' },
+      2: { name: 'Bob', text: '   ' },
+    })
+
+    expect(lines).toStrictEqual([{ id: '1', text: 'Alice: still talk' }])
+  })
+
+  test('handles a missing map', () => {
+    expect(assembleCostreamInterimLines(undefined)).toStrictEqual([])
+  })
+})

--- a/src/components/Captions/helpers.js
+++ b/src/components/Captions/helpers.js
@@ -161,24 +161,84 @@ export function assembleCaptionText(
   )
 }
 
+// Normalize a queue entry into a display line: co-streamer guest entries
+// (which carry a name) are prefixed "Name: ", broadcaster entries unchanged.
+function toDisplayLine({ id, text, name }) {
+  const normalized = normalizeSegment(text)
+
+  if (normalized.length === 0) {
+    return { id, text: '' }
+  }
+
+  return { id, text: name ? `${name}: ${normalized}` : normalized }
+}
+
 /**
  * Assemble the captions as an ordered list of display lines (one per
  * recognized segment / sentence) for a roll-up layout. Each line keeps its
  * stable id so React can key it across renders; empty segments are dropped.
  *
+ * Co-streamer guest lines live in finalTextQueue alongside broadcaster lines
+ * (marked by their `name`/`guestId` fields) and render name-prefixed. In the
+ * default language they interleave chronologically. In a translated view the
+ * translation queue has no guest lines (guest text is never translated), so
+ * guests' original-language lines are appended after the translated lines
+ * when `showCostreamInTranslatedView` allows.
+ *
  * @param {string} viewerLanguage - 'default' or a translation language code
- * @param {Array<{id: string, text: string}>} finalTextQueue - source captions
+ * @param {Array<{id: string, text: string, name?: string}>} finalTextQueue
  * @param {Object} translations - map of languageCode -> { textQueue }
+ * @param {{showCostream?: boolean, showCostreamInTranslatedView?: boolean}} options
  * @returns {Array<{id: string, text: string}>} normalized, non-empty lines
  */
 export function assembleCaptionLines(
   viewerLanguage,
   finalTextQueue,
   translations,
+  options = {},
 ) {
-  return getCaptionQueue(viewerLanguage, finalTextQueue, translations)
-    .map(({ id, text }) => ({ id, text: normalizeSegment(text) }))
+  const { showCostream = true, showCostreamInTranslatedView = true } = options
+
+  if (viewerLanguage === 'default') {
+    return finalTextQueue
+      .filter((entry) => showCostream || !entry.guestId)
+      .map(toDisplayLine)
+      .filter((line) => line.text.length > 0)
+  }
+
+  const translatedLines = getCaptionQueue(
+    viewerLanguage,
+    finalTextQueue,
+    translations,
+  )
+    .map(toDisplayLine)
     .filter((line) => line.text.length > 0)
+
+  if (!showCostream || !showCostreamInTranslatedView) {
+    return translatedLines
+  }
+
+  const guestLines = finalTextQueue
+    .filter((entry) => entry.guestId)
+    .map(toDisplayLine)
+    .filter((line) => line.text.length > 0)
+
+  return [...translatedLines, ...guestLines]
+}
+
+/**
+ * Build the per-guest interim lines to render below the main interim text.
+ *
+ * @param {Object} costreamInterim - map of guestId -> { name, text }
+ * @returns {Array<{id: string, text: string}>} name-prefixed interim lines
+ */
+export function assembleCostreamInterimLines(costreamInterim) {
+  return Object.entries(costreamInterim || {})
+    .filter(([, { text }]) => (text || '').trim().length > 0)
+    .map(([guestId, { name, text }]) => ({
+      id: guestId,
+      text: `${name}: ${text}`,
+    }))
 }
 
 /**

--- a/src/components/display-settings-menu/settings/SettingMenu.jsx
+++ b/src/components/display-settings-menu/settings/SettingMenu.jsx
@@ -3,6 +3,7 @@ import { Menu } from '@blueprintjs/core'
 import {
   AdvancedSettings,
   BoxSizeButton,
+  CostreamCaptionsOptionButton,
   DevMockControls,
   FontFamilyOptions,
   FontSizeOptions,
@@ -20,6 +21,7 @@ const SettingsMenu = () => (
     <GrayOutFinalTextOptionButton />
     <UppercaseTextOptionButton />
     <RollUpCaptionsOptionButton />
+    <CostreamCaptionsOptionButton />
     <LineCountOptions />
     <ResetButton />
     <BoxSizeButton />

--- a/src/components/display-settings-menu/settings/items/CostreamCaptionsOptionButton.jsx
+++ b/src/components/display-settings-menu/settings/items/CostreamCaptionsOptionButton.jsx
@@ -8,8 +8,8 @@ import {
 } from '@/redux/redux-helpers'
 
 import {
-  toggleCostreamCaptions,
-  toggleCostreamInTranslatedView,
+  toggleCostreamCaptionsAndPersist,
+  toggleCostreamInTranslatedViewAndPersist,
 } from '@/redux/settings-slice'
 
 /**
@@ -20,9 +20,9 @@ import {
  * text or hiding guests while translated.
  */
 function CostreamCaptionsOptionButton() {
-  const onToggle = useReduxCallbackDispatch(toggleCostreamCaptions())
+  const onToggle = useReduxCallbackDispatch(toggleCostreamCaptionsAndPersist())
   const onToggleTranslatedView = useReduxCallbackDispatch(
-    toggleCostreamInTranslatedView(),
+    toggleCostreamInTranslatedViewAndPersist(),
   )
   const showCostream = useShallowEqualSelector(
     (state) => state.configSettings.showCostreamCaptions,

--- a/src/components/display-settings-menu/settings/items/CostreamCaptionsOptionButton.jsx
+++ b/src/components/display-settings-menu/settings/items/CostreamCaptionsOptionButton.jsx
@@ -1,0 +1,62 @@
+import { MenuDivider, MenuItem } from '@blueprintjs/core'
+import { faUserFriends } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+
+import {
+  useReduxCallbackDispatch,
+  useShallowEqualSelector,
+} from '@/redux/redux-helpers'
+
+import {
+  toggleCostreamCaptions,
+  toggleCostreamInTranslatedView,
+} from '@/redux/settings-slice'
+
+/**
+ * Viewer toggles for co-streamer guest captions. The master toggle shows or
+ * hides all guest captions. The translated-view sub-toggle only matters when
+ * the viewer is watching a translation language — guest captions are never
+ * translated, so the viewer chooses between seeing guests' original-language
+ * text or hiding guests while translated.
+ */
+function CostreamCaptionsOptionButton() {
+  const onToggle = useReduxCallbackDispatch(toggleCostreamCaptions())
+  const onToggleTranslatedView = useReduxCallbackDispatch(
+    toggleCostreamInTranslatedView(),
+  )
+  const showCostream = useShallowEqualSelector(
+    (state) => state.configSettings.showCostreamCaptions,
+  )
+  const showInTranslatedView = useShallowEqualSelector(
+    (state) => state.configSettings.showCostreamInTranslatedView,
+  )
+  const viewerLanguage = useShallowEqualSelector(
+    (state) => state.configSettings.viewerLanguage,
+  )
+
+  return (
+    <>
+      <MenuDivider />
+      <MenuItem
+        active={showCostream}
+        icon={<FontAwesomeIcon icon={faUserFriends} size="lg" />}
+        onClick={onToggle}
+        shouldDismissPopover={false}
+        text="Co-Streamer Captions"
+      />
+      {showCostream && viewerLanguage !== 'default' && (
+        <MenuItem
+          active={showInTranslatedView}
+          icon={<FontAwesomeIcon icon={faUserFriends} size="lg" />}
+          onClick={onToggleTranslatedView}
+          shouldDismissPopover={false}
+          text="Co-Streamers While Translated"
+        />
+      )}
+    </>
+  )
+}
+
+CostreamCaptionsOptionButton.propTypes = {}
+
+export default CostreamCaptionsOptionButton

--- a/src/components/display-settings-menu/settings/items/index.js
+++ b/src/components/display-settings-menu/settings/items/index.js
@@ -1,5 +1,6 @@
 export { default as AdvancedSettings } from './AdvancedSettings.jsx'
 export { default as BoxSizeButton } from './BoxSizeButton.jsx'
+export { default as CostreamCaptionsOptionButton } from './CostreamCaptionsOptionButton.jsx'
 export { default as DevMockControls } from './DevMockControls.jsx'
 export { default as FontFamilyOptions } from './FontFamilyOptions.jsx'
 export { default as FontSizeOptions } from './FontSizeOptions.jsx'

--- a/src/redux/__tests__/captionsSlice.test.js
+++ b/src/redux/__tests__/captionsSlice.test.js
@@ -38,6 +38,7 @@ beforeAll(async () => {
 const initialState = {
   finalTextQueue: [],
   interimText: '',
+  costreamInterim: {},
   translations: {},
   captionsSubscription: null,
 }

--- a/src/redux/__tests__/costreamCaptions.test.js
+++ b/src/redux/__tests__/costreamCaptions.test.js
@@ -14,16 +14,24 @@ vi.mock('@/utils', () => ({
 // The setup file loads the root reducer (and the real @/utils) before this
 // test runs, so re-import the slice after resetting the module registry to
 // make it pick up the mocked @/utils.
+let utils
 let captions
 let updateCCText
 let updateCostreamText
+let subscribeToCostreamCaptions
+let stopCaptions
+let stopCaptionsSubscription
 
 beforeAll(async () => {
   vi.resetModules()
+  utils = await import('@/utils')
   ;({
     default: captions,
     updateCCText,
     updateCostreamText,
+    subscribeToCostreamCaptions,
+    stopCaptions,
+    stopCaptionsSubscription,
   } = await import('../captions-slice'))
 })
 
@@ -193,5 +201,86 @@ describe('updateCostreamText', () => {
 
     expect(state.finalTextQueue).toHaveLength(TEXT_QUEUE_SIZE)
     expect(state.finalTextQueue[0].text).toBe('line 5')
+  })
+})
+
+describe('subscribeToCostreamCaptions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const getState = () => ({ videoPlayerContext: { hlsLatencyBroadcaster: 2 } })
+
+  function mockSubscription() {
+    const handle = { observer: null, unsubscribe: vi.fn() }
+    utils.apolloClient.subscribe.mockReturnValue({
+      subscribe: (subscriber) => {
+        handle.observer = subscriber
+        return { unsubscribe: handle.unsubscribe }
+      },
+    })
+    return handle
+  }
+
+  test('connects the socket and dispatches guest captions delayed by HLS latency', () => {
+    const handle = mockSubscription()
+    const dispatch = vi.fn()
+
+    subscribeToCostreamCaptions('costream-chan-1')(dispatch, getState)
+
+    expect(utils.connectPhoenixSocket).toHaveBeenCalled()
+    expect(utils.apolloClient.subscribe).toHaveBeenCalledWith(
+      expect.objectContaining({ variables: { channelId: 'costream-chan-1' } }),
+    )
+
+    const caption = { guestId: '1', name: 'Alice', interim: 'hi', final: '' }
+    handle.observer.next({ data: { newCostreamCaption: caption } })
+
+    expect(dispatch).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(2000)
+
+    expect(dispatch).toHaveBeenCalledWith(updateCostreamText(caption))
+  })
+
+  test('re-subscribing for the same channel reuses the live subscription', () => {
+    mockSubscription()
+    const dispatch = vi.fn()
+
+    const first = subscribeToCostreamCaptions('costream-chan-2')(
+      dispatch,
+      getState,
+    )
+    utils.apolloClient.subscribe.mockClear()
+
+    const second = subscribeToCostreamCaptions('costream-chan-2')(
+      dispatch,
+      getState,
+    )
+
+    expect(second).toBe(first)
+    expect(utils.apolloClient.subscribe).not.toHaveBeenCalled()
+  })
+
+  test('stopCaptions unsubscribes live handles and clears caption state', () => {
+    const handle = mockSubscription()
+    const dispatch = vi.fn()
+
+    subscribeToCostreamCaptions('costream-chan-3')(dispatch, getState)
+
+    stopCaptions()(dispatch)
+
+    expect(handle.unsubscribe).toHaveBeenCalled()
+    expect(dispatch).toHaveBeenCalledWith(stopCaptionsSubscription())
+
+    // After stopping, subscribing again creates a fresh subscription.
+    utils.apolloClient.subscribe.mockClear()
+    mockSubscription()
+    subscribeToCostreamCaptions('costream-chan-3')(dispatch, getState)
+    expect(utils.apolloClient.subscribe).toHaveBeenCalled()
   })
 })

--- a/src/redux/__tests__/costreamCaptions.test.js
+++ b/src/redux/__tests__/costreamCaptions.test.js
@@ -1,0 +1,197 @@
+import { TEXT_QUEUE_SIZE } from '@/utils/Constants'
+
+vi.mock('@/utils', () => ({
+  apolloClient: {
+    subscribe: vi.fn(),
+    query: vi.fn(),
+    mutate: vi.fn(),
+  },
+  connectPhoenixSocket: vi.fn(),
+  isPhoenixSocketConnected: vi.fn(),
+  disconnectPhoenixSocket: vi.fn(),
+}))
+
+// The setup file loads the root reducer (and the real @/utils) before this
+// test runs, so re-import the slice after resetting the module registry to
+// make it pick up the mocked @/utils.
+let captions
+let updateCCText
+let updateCostreamText
+
+beforeAll(async () => {
+  vi.resetModules()
+  ;({
+    default: captions,
+    updateCCText,
+    updateCostreamText,
+  } = await import('../captions-slice'))
+})
+
+const initialState = {
+  finalTextQueue: [],
+  interimText: '',
+  costreamInterim: {},
+  translations: {},
+  captionsSubscription: null,
+}
+
+describe('updateCostreamText', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('tracks per-guest interim text', () => {
+    const state = captions(
+      initialState,
+      updateCostreamText({
+        guestId: '1',
+        name: 'Alice',
+        interim: 'hello wor',
+        final: '',
+      }),
+    )
+
+    expect(state.costreamInterim).toStrictEqual({
+      1: { name: 'Alice', text: 'hello wor' },
+    })
+    expect(state.finalTextQueue).toStrictEqual([])
+    // Host interim untouched
+    expect(state.interimText).toBe('')
+  })
+
+  test('clears a guest interim when their final arrives', () => {
+    let state = captions(
+      initialState,
+      updateCostreamText({
+        guestId: '1',
+        name: 'Alice',
+        interim: 'hello wor',
+        final: '',
+      }),
+    )
+
+    state = captions(
+      state,
+      updateCostreamText({
+        guestId: '1',
+        name: 'Alice',
+        interim: '',
+        final: 'hello world',
+      }),
+    )
+
+    expect(state.costreamInterim).toStrictEqual({})
+    expect(state.finalTextQueue).toHaveLength(1)
+    expect(state.finalTextQueue[0]).toMatchObject({
+      guestId: '1',
+      name: 'Alice',
+      text: 'hello world',
+    })
+  })
+
+  test('keeps separate interims for concurrent guests', () => {
+    let state = captions(
+      initialState,
+      updateCostreamText({
+        guestId: '1',
+        name: 'Alice',
+        interim: 'one',
+        final: '',
+      }),
+    )
+    state = captions(
+      state,
+      updateCostreamText({
+        guestId: '2',
+        name: 'Bob',
+        interim: 'two',
+        final: '',
+      }),
+    )
+
+    expect(state.costreamInterim).toStrictEqual({
+      1: { name: 'Alice', text: 'one' },
+      2: { name: 'Bob', text: 'two' },
+    })
+  })
+
+  test('dedupes repeated finals per guest', () => {
+    const payload = {
+      guestId: '1',
+      name: 'Alice',
+      interim: '',
+      final: 'same thing',
+    }
+
+    let state = captions(initialState, updateCostreamText(payload))
+    state = captions(state, updateCostreamText(payload))
+
+    expect(state.finalTextQueue).toHaveLength(1)
+  })
+
+  test('a guest line in between does not defeat host dedupe (and vice versa)', () => {
+    let state = captions(
+      initialState,
+      updateCCText({ interim: '', final: 'host says hi' }),
+    )
+    state = captions(
+      state,
+      updateCostreamText({
+        guestId: '1',
+        name: 'Alice',
+        interim: '',
+        final: 'guest line',
+      }),
+    )
+    // Same host final again (e.g. duplicate frame) — must not re-append
+    state = captions(
+      state,
+      updateCCText({ interim: '', final: 'host says hi' }),
+    )
+
+    const texts = state.finalTextQueue.map(({ text }) => text)
+    expect(texts).toStrictEqual(['host says hi', 'guest line'])
+  })
+
+  test('host and guest finals interleave chronologically', () => {
+    let state = captions(
+      initialState,
+      updateCCText({ interim: '', final: 'first host' }),
+    )
+    state = captions(
+      state,
+      updateCostreamText({
+        guestId: '1',
+        name: 'Alice',
+        interim: '',
+        final: 'then guest',
+      }),
+    )
+    state = captions(state, updateCCText({ interim: '', final: 'host again' }))
+
+    expect(state.finalTextQueue.map(({ text }) => text)).toStrictEqual([
+      'first host',
+      'then guest',
+      'host again',
+    ])
+  })
+
+  test('caps the shared queue at TEXT_QUEUE_SIZE', () => {
+    let state = initialState
+
+    for (let i = 0; i < TEXT_QUEUE_SIZE + 5; i++) {
+      state = captions(
+        state,
+        updateCostreamText({
+          guestId: '1',
+          name: 'Alice',
+          interim: '',
+          final: `line ${i}`,
+        }),
+      )
+    }
+
+    expect(state.finalTextQueue).toHaveLength(TEXT_QUEUE_SIZE)
+    expect(state.finalTextQueue[0].text).toBe('line 5')
+  })
+})

--- a/src/redux/__tests__/costreamSettings.test.js
+++ b/src/redux/__tests__/costreamSettings.test.js
@@ -1,0 +1,51 @@
+let settings
+let toggleCostreamCaptions
+let toggleCostreamInTranslatedView
+let initialState
+
+describe('costream viewer settings', () => {
+  beforeEach(async () => {
+    window.localStorage.clear()
+    vi.resetModules()
+    ;({
+      default: settings,
+      toggleCostreamCaptions,
+      toggleCostreamInTranslatedView,
+      initialState,
+    } = await import('../settings-slice'))
+  })
+
+  test('guest captions are shown by default', () => {
+    expect(initialState.showCostreamCaptions).toBe(true)
+    expect(initialState.showCostreamInTranslatedView).toBe(true)
+  })
+
+  test('toggleCostreamCaptions flips and persists the choice', async () => {
+    const state = settings(initialState, toggleCostreamCaptions())
+
+    expect(state.showCostreamCaptions).toBe(false)
+
+    // A fresh module load (new page load) reads the persisted preference.
+    vi.resetModules()
+    const reloaded = await import('../settings-slice')
+    expect(reloaded.initialState.showCostreamCaptions).toBe(false)
+  })
+
+  test('toggleCostreamInTranslatedView flips and persists the choice', async () => {
+    const state = settings(initialState, toggleCostreamInTranslatedView())
+
+    expect(state.showCostreamInTranslatedView).toBe(false)
+
+    vi.resetModules()
+    const reloaded = await import('../settings-slice')
+    expect(reloaded.initialState.showCostreamInTranslatedView).toBe(false)
+  })
+
+  test('survives an unreadable localStorage payload', async () => {
+    window.localStorage.setItem('viewerPrefs', 'not json')
+
+    vi.resetModules()
+    const reloaded = await import('../settings-slice')
+    expect(reloaded.initialState.showCostreamCaptions).toBe(true)
+  })
+})

--- a/src/redux/__tests__/costreamSettings.test.js
+++ b/src/redux/__tests__/costreamSettings.test.js
@@ -1,7 +1,15 @@
+import { configureStore } from '@reduxjs/toolkit'
+
 let settings
 let toggleCostreamCaptions
 let toggleCostreamInTranslatedView
+let toggleCostreamCaptionsAndPersist
+let toggleCostreamInTranslatedViewAndPersist
 let initialState
+
+function buildStore() {
+  return configureStore({ reducer: { configSettings: settings } })
+}
 
 describe('costream viewer settings', () => {
   beforeEach(async () => {
@@ -11,6 +19,8 @@ describe('costream viewer settings', () => {
       default: settings,
       toggleCostreamCaptions,
       toggleCostreamInTranslatedView,
+      toggleCostreamCaptionsAndPersist,
+      toggleCostreamInTranslatedViewAndPersist,
       initialState,
     } = await import('../settings-slice'))
   })
@@ -20,10 +30,21 @@ describe('costream viewer settings', () => {
     expect(initialState.showCostreamInTranslatedView).toBe(true)
   })
 
-  test('toggleCostreamCaptions flips and persists the choice', async () => {
+  test('the reducers are pure toggles (no persistence)', () => {
     const state = settings(initialState, toggleCostreamCaptions())
-
     expect(state.showCostreamCaptions).toBe(false)
+
+    const translated = settings(initialState, toggleCostreamInTranslatedView())
+    expect(translated.showCostreamInTranslatedView).toBe(false)
+
+    expect(window.localStorage.getItem('viewerPrefs')).toBeNull()
+  })
+
+  test('the persist thunk flips and persists across a reload', async () => {
+    const store = buildStore()
+    store.dispatch(toggleCostreamCaptionsAndPersist())
+
+    expect(store.getState().configSettings.showCostreamCaptions).toBe(false)
 
     // A fresh module load (new page load) reads the persisted preference.
     vi.resetModules()
@@ -31,10 +52,13 @@ describe('costream viewer settings', () => {
     expect(reloaded.initialState.showCostreamCaptions).toBe(false)
   })
 
-  test('toggleCostreamInTranslatedView flips and persists the choice', async () => {
-    const state = settings(initialState, toggleCostreamInTranslatedView())
+  test('the translated-view thunk flips and persists across a reload', async () => {
+    const store = buildStore()
+    store.dispatch(toggleCostreamInTranslatedViewAndPersist())
 
-    expect(state.showCostreamInTranslatedView).toBe(false)
+    expect(store.getState().configSettings.showCostreamInTranslatedView).toBe(
+      false,
+    )
 
     vi.resetModules()
     const reloaded = await import('../settings-slice')

--- a/src/redux/captions-slice.js
+++ b/src/redux/captions-slice.js
@@ -132,28 +132,55 @@ const captionsSlice = createSlice({
   },
 })
 
+// Live Apollo subscription handles, keyed by stream kind. They are not
+// serializable, so they live here rather than in the store; the subscribe
+// thunks below gate on them so a re-run effect (visibility toggle, auth
+// re-resolve) can't stack duplicate subscriptions, and stopCaptions tears
+// them down explicitly before the socket disconnects.
+const activeSubscriptions = {
+  captions: null, // { channelId, subscription }
+  costream: null,
+}
+
+function subscribeOnce(kind, channelId, query, onNext) {
+  const existing = activeSubscriptions[kind]
+
+  if (existing && existing.channelId === channelId) {
+    return existing.subscription
+  }
+
+  if (existing) {
+    existing.subscription.unsubscribe()
+    activeSubscriptions[kind] = null
+  }
+
+  // Connect Phoenix socket (safe no-op if socket doesn't exist in dev mode)
+  connectPhoenixSocket()
+
+  const subscription = apolloClient
+    .subscribe({ variables: { channelId }, query })
+    .subscribe({ next: onNext })
+
+  activeSubscriptions[kind] = { channelId, subscription }
+  return subscription
+}
+
 export function subscribeToCaptions(channelId) {
   return function thunk(dispatch, getState) {
-    // Connect Phoenix socket (safe no-op if socket doesn't exist in dev mode)
-    connectPhoenixSocket()
+    return subscribeOnce(
+      'captions',
+      channelId,
+      subscriptionNewCaptions,
+      ({ data: { newTwitchCaption } }) => {
+        const hlsLatencyBroadcaster = hlsLatencyBroadcasterSelector(getState())
 
-    return apolloClient
-      .subscribe({
-        variables: { channelId },
-        query: subscriptionNewCaptions,
-      })
-      .subscribe({
-        next({ data: { newTwitchCaption } }) {
-          const hlsLatencyBroadcaster =
-            hlsLatencyBroadcasterSelector(getState())
+        let delayTimeMilliseconds = hlsLatencyBroadcaster * 1000
 
-          let delayTimeMilliseconds = hlsLatencyBroadcaster * 1000
-
-          setTimeout(() => {
-            dispatch(updateCCText(newTwitchCaption))
-          }, delayTimeMilliseconds)
-        },
-      })
+        setTimeout(() => {
+          dispatch(updateCCText(newTwitchCaption))
+        }, delayTimeMilliseconds)
+      },
+    )
   }
 }
 
@@ -161,25 +188,37 @@ export function subscribeToCaptions(channelId) {
 // guest lines stay roughly in sync with the video like broadcaster lines do.
 export function subscribeToCostreamCaptions(channelId) {
   return function thunk(dispatch, getState) {
-    connectPhoenixSocket()
+    return subscribeOnce(
+      'costream',
+      channelId,
+      subscriptionNewCostreamCaptions,
+      ({ data: { newCostreamCaption } }) => {
+        const hlsLatencyBroadcaster = hlsLatencyBroadcasterSelector(getState())
 
-    return apolloClient
-      .subscribe({
-        variables: { channelId },
-        query: subscriptionNewCostreamCaptions,
-      })
-      .subscribe({
-        next({ data: { newCostreamCaption } }) {
-          const hlsLatencyBroadcaster =
-            hlsLatencyBroadcasterSelector(getState())
+        let delayTimeMilliseconds = hlsLatencyBroadcaster * 1000
 
-          let delayTimeMilliseconds = hlsLatencyBroadcaster * 1000
+        setTimeout(() => {
+          dispatch(updateCostreamText(newCostreamCaption))
+        }, delayTimeMilliseconds)
+      },
+    )
+  }
+}
 
-          setTimeout(() => {
-            dispatch(updateCostreamText(newCostreamCaption))
-          }, delayTimeMilliseconds)
-        },
-      })
+// Unsubscribes both caption streams before the reducer disconnects the
+// socket and clears caption state, so nothing re-subscribes on reconnect.
+export function stopCaptions() {
+  return function thunk(dispatch) {
+    for (const kind of Object.keys(activeSubscriptions)) {
+      const active = activeSubscriptions[kind]
+
+      if (active) {
+        active.subscription.unsubscribe()
+        activeSubscriptions[kind] = null
+      }
+    }
+
+    dispatch(stopCaptionsSubscription())
   }
 }
 

--- a/src/redux/captions-slice.js
+++ b/src/redux/captions-slice.js
@@ -49,6 +49,7 @@ const captionsSlice = createSlice({
       if (isPhoenixSocketConnected()) {
         disconnectPhoenixSocket()
         state.finalTextQueue = []
+        state.interimText = ''
         state.costreamInterim = {}
         state.translations = {}
       }

--- a/src/redux/captions-slice.js
+++ b/src/redux/captions-slice.js
@@ -8,16 +8,34 @@ import {
   disconnectPhoenixSocket,
 } from '../utils'
 
-import { subscriptionNewCaptions } from './utils'
+import {
+  subscriptionNewCaptions,
+  subscriptionNewCostreamCaptions,
+} from './utils'
 import { hlsLatencyBroadcasterSelector } from './selectors'
 
 import { TEXT_QUEUE_SIZE } from '@/utils/Constants'
 
 const initialState = {
+  // Chronological feed of final caption segments. Broadcaster entries are
+  // { id, text }; co-streamer guest entries additionally carry
+  // { guestId, name } so views can prefix/filter them.
   finalTextQueue: [],
   interimText: '',
+  // Live interim text per connected guest: guestId -> { name, text }
+  costreamInterim: {},
   translations: {},
   captionsSubscription: null,
+}
+
+// Dedupe finals per speaker: the broadcaster's repeat-suppression must not be
+// defeated by a guest line landing in between (and vice versa).
+function lastEntryFor(queue, guestId) {
+  for (let i = queue.length - 1; i >= 0; i--) {
+    const entry = queue[i]
+    if ((entry.guestId || null) === (guestId || null)) return entry
+  }
+  return {}
 }
 
 const captionsSlice = createSlice({
@@ -31,17 +49,17 @@ const captionsSlice = createSlice({
       if (isPhoenixSocketConnected()) {
         disconnectPhoenixSocket()
         state.finalTextQueue = []
+        state.costreamInterim = {}
         state.translations = {}
       }
     },
 
     updateCCText(state, action) {
       const newTranslations = state.translations
-      const qLength = state.finalTextQueue.length
 
       state.interimText = action.payload.interim
 
-      const lastText = state.finalTextQueue[qLength - 1] || {}
+      const lastText = lastEntryFor(state.finalTextQueue, null)
 
       if (lastText.text !== action.payload.final) {
         state.finalTextQueue.push({ id: uuid(), text: action.payload.final })
@@ -85,6 +103,31 @@ const captionsSlice = createSlice({
         state.translations = newTranslations
       }
     },
+
+    // Guest (co-streamer) captions: no translations, no pirate mode — just
+    // interim + final text attributed to a guest. Finals land in the shared
+    // finalTextQueue so broadcaster and guest lines interleave chronologically.
+    updateCostreamText(state, action) {
+      const { guestId, name, interim, final } = action.payload
+
+      if (interim) {
+        state.costreamInterim[guestId] = { name, text: interim }
+      } else {
+        delete state.costreamInterim[guestId]
+      }
+
+      if (final) {
+        const lastText = lastEntryFor(state.finalTextQueue, guestId)
+
+        if (lastText.text !== final) {
+          state.finalTextQueue.push({ id: uuid(), guestId, name, text: final })
+
+          if (state.finalTextQueue.length > TEXT_QUEUE_SIZE) {
+            state.finalTextQueue.shift()
+          }
+        }
+      }
+    },
   },
 })
 
@@ -113,8 +156,35 @@ export function subscribeToCaptions(channelId) {
   }
 }
 
+// Mirrors subscribeToCaptions, including the broadcaster-latency delay so
+// guest lines stay roughly in sync with the video like broadcaster lines do.
+export function subscribeToCostreamCaptions(channelId) {
+  return function thunk(dispatch, getState) {
+    connectPhoenixSocket()
+
+    return apolloClient
+      .subscribe({
+        variables: { channelId },
+        query: subscriptionNewCostreamCaptions,
+      })
+      .subscribe({
+        next({ data: { newCostreamCaption } }) {
+          const hlsLatencyBroadcaster =
+            hlsLatencyBroadcasterSelector(getState())
+
+          let delayTimeMilliseconds = hlsLatencyBroadcaster * 1000
+
+          setTimeout(() => {
+            dispatch(updateCostreamText(newCostreamCaption))
+          }, delayTimeMilliseconds)
+        },
+      })
+  }
+}
+
 export const {
   updateCCText,
+  updateCostreamText,
   setCaptionsSubscription,
   stopCaptionsSubscription,
 } = captionsSlice.actions

--- a/src/redux/settings-slice.js
+++ b/src/redux/settings-slice.js
@@ -6,8 +6,18 @@ import {
   CAPTIONS_SIZE,
   CAPTIONS_TRANSPARENCY,
 } from '@/utils/Constants'
+import { loadViewerPrefs, saveViewerPref } from '@/utils/viewer-prefs'
+
+const viewerPrefs = loadViewerPrefs()
 
 export const initialState = {
+  // Co-streamer guest caption visibility — persisted per viewer, unlike the
+  // rest of this slice, so hiding guests survives a reload.
+  showCostreamCaptions: viewerPrefs.showCostreamCaptions ?? true,
+  // When watching a translated language (guest captions are never
+  // translated): show guests' original-language text, or hide them.
+  showCostreamInTranslatedView:
+    viewerPrefs.showCostreamInTranslatedView ?? true,
   boxLineCount: 7,
   captionsTransparency: CAPTIONS_TRANSPARENCY.default,
   captionsWidth: CAPTIONS_SIZE.defaultHorizontalWidth,
@@ -116,6 +126,17 @@ const settingsSlice = createSlice({
     toggleUppercaseText(state) {
       state.textUppercase = !state.textUppercase
     },
+    toggleCostreamCaptions(state) {
+      state.showCostreamCaptions = !state.showCostreamCaptions
+      saveViewerPref('showCostreamCaptions', state.showCostreamCaptions)
+    },
+    toggleCostreamInTranslatedView(state) {
+      state.showCostreamInTranslatedView = !state.showCostreamInTranslatedView
+      saveViewerPref(
+        'showCostreamInTranslatedView',
+        state.showCostreamInTranslatedView,
+      )
+    },
     toggleVisibility(state) {
       state.hideCC = !state.hideCC
     },
@@ -148,6 +169,8 @@ export const {
   toggleActivationDrawer,
   toggleAdvancedSettingsDialog,
   toggleBoxSize,
+  toggleCostreamCaptions,
+  toggleCostreamInTranslatedView,
   toggleDyslexiaFamily,
   toggleGrayOutFinalText,
   toggleRollUpCaptions,

--- a/src/redux/settings-slice.js
+++ b/src/redux/settings-slice.js
@@ -128,14 +128,9 @@ const settingsSlice = createSlice({
     },
     toggleCostreamCaptions(state) {
       state.showCostreamCaptions = !state.showCostreamCaptions
-      saveViewerPref('showCostreamCaptions', state.showCostreamCaptions)
     },
     toggleCostreamInTranslatedView(state) {
       state.showCostreamInTranslatedView = !state.showCostreamInTranslatedView
-      saveViewerPref(
-        'showCostreamInTranslatedView',
-        state.showCostreamInTranslatedView,
-      )
     },
     toggleVisibility(state) {
       state.hideCC = !state.hideCC
@@ -155,6 +150,28 @@ const settingsSlice = createSlice({
     },
   },
 })
+
+// Persistence lives in thunks so the reducers above stay pure (same pattern
+// as completeBitsTransaction's localStorage write in products-slice).
+export function toggleCostreamCaptionsAndPersist() {
+  return function thunk(dispatch, getState) {
+    dispatch(toggleCostreamCaptions())
+    saveViewerPref(
+      'showCostreamCaptions',
+      getState().configSettings.showCostreamCaptions,
+    )
+  }
+}
+
+export function toggleCostreamInTranslatedViewAndPersist() {
+  return function thunk(dispatch, getState) {
+    dispatch(toggleCostreamInTranslatedView())
+    saveViewerPref(
+      'showCostreamInTranslatedView',
+      getState().configSettings.showCostreamInTranslatedView,
+    )
+  }
+}
 
 export const {
   changeCaptionsTransparency,

--- a/src/redux/utils/graphql.js
+++ b/src/redux/utils/graphql.js
@@ -33,3 +33,17 @@ export const subscriptionNewCaptions = gql`
     }
   }
 `
+
+// Guest (co-streamer) captions ride a separate subscription so extension
+// versions released before this feature keep working untouched — their
+// hardcoded newTwitchCaption query never sees guest text.
+export const subscriptionNewCostreamCaptions = gql`
+  subscription OnCostreamCaption($channelId: ID!) {
+    newCostreamCaption(channelId: $channelId) {
+      guestId
+      name
+      interim
+      final
+    }
+  }
+`

--- a/src/utils/viewer-prefs.js
+++ b/src/utils/viewer-prefs.js
@@ -1,0 +1,27 @@
+const STORAGE_KEY = 'viewerPrefs'
+
+/**
+ * Viewer preferences persisted across page loads. Redux settings state is
+ * otherwise in-memory only, which is fine for layout tweaks but not for the
+ * co-streamer visibility choice — a viewer who hides guest captions expects
+ * that to stick. localStorage can be unavailable inside the extension iframe
+ * (sandbox/privacy modes), so every access is best-effort.
+ */
+export function loadViewerPrefs() {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    return raw ? JSON.parse(raw) : {}
+  } catch (_error) {
+    return {}
+  }
+}
+
+export function saveViewerPref(key, value) {
+  try {
+    const prefs = loadViewerPrefs()
+    prefs[key] = value
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs))
+  } catch (_error) {
+    // Persistence is a nice-to-have; the in-memory value still applies.
+  }
+}


### PR DESCRIPTION
## Summary

Viewer-side support for co-streamer guest captions (backend: talk2MeGooseman/stream_closed_captioner_phoenix#claude/costreamer-captions-stcu3m). Guest captions render interleaved with the broadcaster's, name-prefixed (`Alice: …`), with viewer controls to show/hide them.

## Changes

- **New `newCostreamCaption(channelId)` subscription** consumed alongside `newTwitchCaption`, with the same broadcaster-latency delay. Kept separate on the backend on purpose — released bundles' hardcoded `newTwitchCaption` query never carries guest text, so this PR is purely additive and old versions keep working untouched.
- **Speaker-aware caption store**: guest finals land in the shared `finalTextQueue` tagged `{guestId, name}` so broadcaster and guest lines interleave chronologically; dedupe is now per speaker (`lastEntryFor`) so an interleaved line can't defeat repeat suppression. New `costreamInterim` map renders per-guest interim lines.
- **Rendering**: `assembleCaptionLines` gains an options arg; guest lines render name-prefixed on overlay, mobile, and panel. In translated views (guest text is never translated), guests' original-language lines append after the translated lines — or hide, per viewer choice.
- **Viewer settings**: gear-menu "Co-Streamer Captions" master toggle (on by default) plus a translated-view sub-toggle. Both persist to localStorage via a new `viewer-prefs` util — the first persisted viewer settings in the extension (best-effort, safe when localStorage is unavailable).

## Test plan

- `yarn test`: 427 tests across 56 files, 0 failures — new suites cover the costream reducer (interleaving, per-speaker dedupe, queue cap, per-guest interim), the render helpers (prefixing, hide toggles, translated-view behavior), and settings persistence (including corrupt-localStorage recovery).
- `yarn lint` clean; `yarn build` (Vite production) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9S37dZYFfF7qhkjCohFAN

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9S37dZYFfF7qhkjCohFAN)_